### PR TITLE
update input interfaces

### DIFF
--- a/packages/synthetics-sdk-broken-links/src/broken_links.ts
+++ b/packages/synthetics-sdk-broken-links/src/broken_links.ts
@@ -30,8 +30,41 @@ import {
   CommonResponseProps,
 } from './link_utils';
 
+export interface BrokenLinkCheckerOptions {
+  origin_url: string;
+  link_limit?: number;
+  query_selector_all?: string;
+  get_attributes?: string[];
+  link_order?: LinkOrder;
+  link_timeout_millis?: number | undefined;
+  max_retries?: number | undefined;
+  max_redirects?: number | undefined;
+  wait_for_selector?: string;
+  per_link_options?: { [key: string]: PerLinkOption };
+}
+
+export interface PerLinkOption {
+  link_timeout_millis?: number;
+  expected_status_code?: StatusClass | number;
+}
+
+export enum LinkOrder {
+  'FIRST_N',
+  'RANDOM',
+}
+
+export enum StatusClass {
+  STATUS_CLASS_UNSPECIFIED = 'STATUS_CLASS_UNSPECIFIED',
+  STATUS_CLASS_1XX = 'STATUS_CLASS_1XX',
+  STATUS_CLASS_2XX = 'STATUS_CLASS_2XX',
+  STATUS_CLASS_3XX = 'STATUS_CLASS_3XX',
+  STATUS_CLASS_4XX = 'STATUS_CLASS_4XX',
+  STATUS_CLASS_5XX = 'STATUS_CLASS_5XX',
+  STATUS_CLASS_ANY = 'STATUS_CLASS_ANY',
+}
+
 export async function runBrokenLinks(
-  options: BrokenLinksResultV1_BrokenLinkCheckerOptions
+  input_options: BrokenLinkCheckerOptions
 ): Promise<SyntheticResult> {
   // START - to resolve warnings while under development
   checkStatusPassing({ status_value: 200 } as ResponseStatusCode, 200);
@@ -46,7 +79,7 @@ export async function runBrokenLinks(
   // END - to resolve warnings  while under development
 
   // options object modified directly
-  setDefaultOptions(options);
+  const options = setDefaultOptions(input_options);
 
   // PSEUDOCODE
 

--- a/packages/synthetics-sdk-broken-links/src/broken_links.ts
+++ b/packages/synthetics-sdk-broken-links/src/broken_links.ts
@@ -24,7 +24,6 @@ import {
   checkStatusPassing,
   isHTTPResponse,
   LinkIntermediate,
-  setDefaultOptions,
   shouldGoToBlankPage,
   NavigateResponse,
   CommonResponseProps,
@@ -67,8 +66,7 @@ export async function runBrokenLinks(
   input_options: BrokenLinkCheckerOptions
 ): Promise<SyntheticResult> {
   // START - to resolve warnings while under development
-  checkStatusPassing({ status_value: 200 } as ResponseStatusCode, 200);
-
+  input_options;
   const browser = await puppeteer.launch({ headless: 'new' });
   const page = await browser.newPage();
   await checkLink(
@@ -79,8 +77,6 @@ export async function runBrokenLinks(
   // END - to resolve warnings  while under development
 
   // options object modified directly
-  const options = setDefaultOptions(input_options);
-  options;
   // PSEUDOCODE
 
   // create puppeteer.Browser

--- a/packages/synthetics-sdk-broken-links/src/broken_links.ts
+++ b/packages/synthetics-sdk-broken-links/src/broken_links.ts
@@ -79,7 +79,9 @@ export async function runBrokenLinks(
   // END - to resolve warnings  while under development
 
   // options object modified directly
-  const options = setDefaultOptions(input_options);
+  const options: BrokenLinksResultV1_BrokenLinkCheckerOptions =
+    setDefaultOptions(input_options);
+  options;
 
   // PSEUDOCODE
 

--- a/packages/synthetics-sdk-broken-links/src/broken_links.ts
+++ b/packages/synthetics-sdk-broken-links/src/broken_links.ts
@@ -79,10 +79,8 @@ export async function runBrokenLinks(
   // END - to resolve warnings  while under development
 
   // options object modified directly
-  const options: BrokenLinksResultV1_BrokenLinkCheckerOptions =
-    setDefaultOptions(input_options);
+  const options = setDefaultOptions(input_options);
   options;
-
   // PSEUDOCODE
 
   // create puppeteer.Browser

--- a/packages/synthetics-sdk-broken-links/src/handlers.ts
+++ b/packages/synthetics-sdk-broken-links/src/handlers.ts
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { runBrokenLinks } from './broken_links';
-import { BrokenLinkCheckerOptions } from './broken_links';
+import { runBrokenLinks, BrokenLinkCheckerOptions } from './broken_links';
 import { Request, Response } from 'express';
 
 /**

--- a/packages/synthetics-sdk-broken-links/src/handlers.ts
+++ b/packages/synthetics-sdk-broken-links/src/handlers.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { runBrokenLinks } from './broken_links';
-import { BrokenLinksResultV1_BrokenLinkCheckerOptions } from '@google-cloud/synthetics-sdk-api';
+import { BrokenLinkCheckerOptions } from './broken_links';
 import { Request, Response } from 'express';
 
 /**
@@ -24,9 +24,7 @@ import { Request, Response } from 'express';
  * @returns ExpressJS compatible middleware that invokes SyntheticsSDK broken links, and
  * returns the results via res.send
  */
-export function runBrokenLinkHandler(
-  options: BrokenLinksResultV1_BrokenLinkCheckerOptions
-) {
+export function runBrokenLinkHandler(options: BrokenLinkCheckerOptions) {
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   return async (req: Request, res: Response): Promise<any> =>
     res.send(await runBrokenLinks(options));

--- a/packages/synthetics-sdk-broken-links/src/link_utils.ts
+++ b/packages/synthetics-sdk-broken-links/src/link_utils.ts
@@ -154,22 +154,18 @@ export function setDefaultOptions(
     options.per_link_options || {}
   )) {
     perLinkOption.expected_status_code;
-    const expected_status_code =
+    const expected_status_code = (
       perLinkOption.expected_status_code !== undefined
         ? typeof perLinkOption.expected_status_code === 'number'
-          ? ({
-              status_value: perLinkOption.expected_status_code,
-            } as ResponseStatusCode)
-          : ({
+          ? { status_value: perLinkOption.expected_status_code }
+          : {
               status_class:
                 ResponseStatusCode_StatusClass[
                   perLinkOption.expected_status_code
                 ],
-            } as ResponseStatusCode)
-        : ({
-            status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_2XX,
-          } as ResponseStatusCode);
-    console.log('expected_status_code', expected_status_code);
+            }
+        : { status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_2XX }
+    ) as ResponseStatusCode;
 
     const convertedPerLinkOption: BrokenLinksResultV1_BrokenLinkCheckerOptions_PerLinkOption =
       {

--- a/packages/synthetics-sdk-broken-links/src/link_utils.ts
+++ b/packages/synthetics-sdk-broken-links/src/link_utils.ts
@@ -177,9 +177,6 @@ export function setDefaultOptions(
       };
     perLinkOptions[url] = convertedPerLinkOption;
   }
-  output_options.per_link_options = perLinkOptions;
-
-  return output_options;
 }
 
 /**

--- a/packages/synthetics-sdk-broken-links/src/link_utils.ts
+++ b/packages/synthetics-sdk-broken-links/src/link_utils.ts
@@ -140,6 +140,7 @@ export function setDefaultOptions(
     keyof BrokenLinksResultV1_BrokenLinkCheckerOptions
   >;
   for (const key of objKeys) {
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     (output_options as any)[key] =
       !(key in options) || key === 'per_link_options'
         ? default_options[key]

--- a/packages/synthetics-sdk-broken-links/src/link_utils.ts
+++ b/packages/synthetics-sdk-broken-links/src/link_utils.ts
@@ -177,6 +177,8 @@ export function setDefaultOptions(
       };
     perLinkOptions[url] = convertedPerLinkOption;
   }
+  output_options.per_link_options = perLinkOptions;
+  return output_options;
 }
 
 /**

--- a/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
@@ -15,20 +15,20 @@
 import { expect } from 'chai';
 import puppeteer, { Page, Browser, HTTPResponse } from 'puppeteer';
 import sinon from 'sinon';
-import { BrokenLinksResultV1_BrokenLinkCheckerOptions } from '@google-cloud/synthetics-sdk-api';
 import { setDefaultOptions } from '../../src/link_utils';
+import type { BrokenLinkCheckerOptions } from '../../src/broken_links';
 const SyntheticsSdkBrokenLinks = require('synthetics-sdk-broken-links');
 
 describe('GCM Synthetics Broken Links Core Functionality', async () => {
   describe('navigate', async () => {
     // constants
     const link = { target_url: 'https://example.com' };
-    const options: BrokenLinksResultV1_BrokenLinkCheckerOptions = {
+    const input_options: BrokenLinkCheckerOptions = {
       origin_url: 'http://origin.com',
       max_retries: 2,
       link_timeout_millis: 5000,
-    } as BrokenLinksResultV1_BrokenLinkCheckerOptions;
-    setDefaultOptions(options);
+    };
+    const options = setDefaultOptions(input_options);
 
     const failedResponse: Partial<HTTPResponse> = { status: () => 404 };
     const successfulResponse: Partial<HTTPResponse> = { status: () => 200 };

--- a/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
@@ -49,15 +49,15 @@ describe('GCM Synthetics Broken Links Utilies', async () => {
     status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_5XX,
   };
 
-    it('returns correctly when passed a number as ResponseStatusCode', () => {
-      // expecting success
-      expect(checkStatusPassing(status_value_200, 200)).to.be.true;
-      expect(checkStatusPassing(status_value_200, 404)).to.be.false;
+  it('returns correctly when passed a number as ResponseStatusCode', () => {
+    // expecting success
+    expect(checkStatusPassing(status_value_200, 200)).to.be.true;
+    expect(checkStatusPassing(status_value_200, 404)).to.be.false;
 
-      // expecting failure
-      expect(checkStatusPassing(status_value_404, 200)).to.be.false;
-      expect(checkStatusPassing(status_value_404, 404)).to.be.true;
-    });
+    // expecting failure
+    expect(checkStatusPassing(status_value_404, 200)).to.be.false;
+    expect(checkStatusPassing(status_value_404, 404)).to.be.true;
+  });
 
   it('returns correctly when passed a statusClass as ResponseStatusCode', () => {
     // expecting success

--- a/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
@@ -49,7 +49,7 @@ describe('GCM Synthetics Broken Links Utilies', async () => {
     status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_5XX,
   };
 
-  it('returns correctly when passed a number as ResponseStatusCode', () => {
+  it('checkStatusPassing returns correctly when passed a number as ResponseStatusCode', () => {
     // expecting success
     expect(checkStatusPassing(status_value_200, 200)).to.be.true;
     expect(checkStatusPassing(status_value_200, 404)).to.be.false;

--- a/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
@@ -14,11 +14,15 @@
 
 import { expect } from 'chai';
 import {
-  BrokenLinksResultV1_BrokenLinkCheckerOptions,
   BrokenLinksResultV1_BrokenLinkCheckerOptions_LinkOrder,
   ResponseStatusCode,
   ResponseStatusCode_StatusClass,
 } from '@google-cloud/synthetics-sdk-api';
+import {
+  BrokenLinkCheckerOptions,
+  StatusClass,
+  LinkOrder,
+} from '../../src/broken_links';
 import {
   checkStatusPassing,
   setDefaultOptions,
@@ -26,70 +30,75 @@ import {
 } from '../../src/link_utils';
 
 describe('GCM Synthetics Broken Links Utilies', async () => {
-  describe('checkStatusPassing', () => {
-    const status_value_200: ResponseStatusCode = { status_value: 200 };
-    const status_value_404: ResponseStatusCode = { status_value: 404 };
-    const status_class_1xx: ResponseStatusCode = {
-      status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_1XX,
-    };
-    const status_class_2xx: ResponseStatusCode = {
-      status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_2XX,
-    };
-    const status_class_3xx: ResponseStatusCode = {
-      status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_3XX,
-    };
-    const status_class_4xx: ResponseStatusCode = {
-      status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_4XX,
-    };
-    const status_class_5xx: ResponseStatusCode = {
-      status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_5XX,
-    };
+  const status_value_200: ResponseStatusCode = { status_value: 200 };
+  const status_value_304: ResponseStatusCode = { status_value: 304 };
+  const status_value_404: ResponseStatusCode = { status_value: 404 };
+  const status_class_1xx: ResponseStatusCode = {
+    status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_1XX,
+  };
+  const status_class_2xx: ResponseStatusCode = {
+    status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_2XX,
+  };
+  const status_class_3xx: ResponseStatusCode = {
+    status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_3XX,
+  };
+  const status_class_4xx: ResponseStatusCode = {
+    status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_4XX,
+  };
+  const status_class_5xx: ResponseStatusCode = {
+    status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_5XX,
+  };
 
-    it('returns correctly when passed a number as ResponseStatusCode', () => {
-      // expecting success
-      expect(checkStatusPassing(status_value_200, 200)).to.be.true;
-      expect(checkStatusPassing(status_value_200, 404)).to.be.false;
+  it('checkStatusPassing returns correctly when passed a number as ResponseStatusCode', () => {
+    // expecting success
+    expect(checkStatusPassing(status_value_200, 200)).to.be.true;
+    expect(checkStatusPassing(status_value_200, 404)).to.be.false;
 
-      // expecting failure
-      expect(checkStatusPassing(status_value_404, 200)).to.be.false;
-      expect(checkStatusPassing(status_value_404, 404)).to.be.true;
-    });
+    // expecting failure
+    expect(checkStatusPassing(status_value_404, 200)).to.be.false;
+    expect(checkStatusPassing(status_value_404, 404)).to.be.true;
+  });
 
-    it('returns correctly when passed a statusClass as ResponseStatusCode', () => {
-      // expecting success
-      expect(checkStatusPassing(status_class_1xx, 100)).to.be.true;
-      expect(checkStatusPassing(status_class_2xx, 200)).to.be.true;
-      expect(checkStatusPassing(status_class_3xx, 304)).to.be.true;
-      expect(checkStatusPassing(status_class_4xx, 404)).to.be.true;
-      expect(checkStatusPassing(status_class_5xx, 504)).to.be.true;
+  it('returns correctly when passed a statusClass as ResponseStatusCode', () => {
+    // expecting success
+    expect(checkStatusPassing(status_class_1xx, 100)).to.be.true;
+    expect(checkStatusPassing(status_class_2xx, 200)).to.be.true;
+    expect(checkStatusPassing(status_class_3xx, 304)).to.be.true;
+    expect(checkStatusPassing(status_class_4xx, 404)).to.be.true;
+    expect(checkStatusPassing(status_class_5xx, 504)).to.be.true;
 
-      // expecting failure
-      expect(checkStatusPassing(status_class_1xx, 200)).to.be.false;
-      expect(checkStatusPassing(status_class_2xx, 404)).to.be.false;
-      expect(checkStatusPassing(status_class_3xx, 200)).to.be.false;
-      expect(checkStatusPassing(status_class_4xx, 200)).to.be.false;
-      expect(checkStatusPassing(status_class_5xx, 200)).to.be.false;
-    });
+    // expecting failure
+    expect(checkStatusPassing(status_class_1xx, 200)).to.be.false;
+    expect(checkStatusPassing(status_class_2xx, 404)).to.be.false;
+    expect(checkStatusPassing(status_class_3xx, 200)).to.be.false;
+    expect(checkStatusPassing(status_class_4xx, 200)).to.be.false;
+    expect(checkStatusPassing(status_class_5xx, 200)).to.be.false;
   });
 
   it('setDefaultOptions only sets non-present values', () => {
-    const options = {
+    const input_options: BrokenLinkCheckerOptions = {
       origin_url: 'https://example.com',
       get_attributes: ['src'],
-      link_order: BrokenLinksResultV1_BrokenLinkCheckerOptions_LinkOrder.RANDOM,
+      link_order: LinkOrder.RANDOM,
       link_timeout_millis: 5000,
       wait_for_selector: '.content',
-    } as BrokenLinksResultV1_BrokenLinkCheckerOptions;
-
-    // sets in place
-    setDefaultOptions(options);
+      per_link_options: {
+        'fake-link1': { expected_status_code: StatusClass.STATUS_CLASS_4XX },
+        'fake-link2': { expected_status_code: 304 },
+        'fake-link3': { link_timeout_millis: 10 },
+        'fake-link4': {
+          expected_status_code: StatusClass.STATUS_CLASS_3XX,
+          link_timeout_millis: 10,
+        },
+      },
+    };
+    const options = setDefaultOptions(input_options);
 
     // Verify that missing values are set to their default values
     expect(options.link_limit).to.equal(50);
     expect(options.query_selector_all).to.equal('a');
     expect(options.max_retries).to.equal(0);
     expect(options.max_redirects).to.equal(Number.MAX_SAFE_INTEGER);
-    expect(options.per_link_options).to.deep.equal({});
 
     // Verify that existing values are not overridden
     expect(options.origin_url).to.equal('https://example.com');
@@ -99,6 +108,26 @@ describe('GCM Synthetics Broken Links Utilies', async () => {
     );
     expect(options.link_timeout_millis).to.equal(5000);
     expect(options.wait_for_selector).to.equal('.content');
+
+    const link_options = {
+      'fake-link1': {
+        expected_status_code: status_class_4xx,
+        link_timeout_millis: 5000,
+      },
+      'fake-link2': {
+        expected_status_code: status_value_304,
+        link_timeout_millis: 5000,
+      },
+      'fake-link3': {
+        expected_status_code: status_class_2xx,
+        link_timeout_millis: 10,
+      },
+      'fake-link4': {
+        expected_status_code: status_class_3xx,
+        link_timeout_millis: 10,
+      },
+    };
+    expect(options.per_link_options).to.deep.equal(link_options);
   });
 
   describe('shouldGoToBlankPage', () => {

--- a/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
@@ -49,7 +49,7 @@ describe('GCM Synthetics Broken Links Utilies', async () => {
     status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_5XX,
   };
 
-  it('checkStatusPassing returns correctly when passed a number as ResponseStatusCode', () => {
+  it('returns correctly when passed a number as ResponseStatusCode', () => {
     // expecting success
     expect(checkStatusPassing(status_value_200, 200)).to.be.true;
     expect(checkStatusPassing(status_value_200, 404)).to.be.false;

--- a/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
@@ -49,15 +49,15 @@ describe('GCM Synthetics Broken Links Utilies', async () => {
     status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_5XX,
   };
 
-  it('checkStatusPassing returns correctly when passed a number as ResponseStatusCode', () => {
-    // expecting success
-    expect(checkStatusPassing(status_value_200, 200)).to.be.true;
-    expect(checkStatusPassing(status_value_200, 404)).to.be.false;
+    it('returns correctly when passed a number as ResponseStatusCode', () => {
+      // expecting success
+      expect(checkStatusPassing(status_value_200, 200)).to.be.true;
+      expect(checkStatusPassing(status_value_200, 404)).to.be.false;
 
-    // expecting failure
-    expect(checkStatusPassing(status_value_404, 200)).to.be.false;
-    expect(checkStatusPassing(status_value_404, 404)).to.be.true;
-  });
+      // expecting failure
+      expect(checkStatusPassing(status_value_404, 200)).to.be.false;
+      expect(checkStatusPassing(status_value_404, 404)).to.be.true;
+    });
 
   it('returns correctly when passed a statusClass as ResponseStatusCode', () => {
     // expecting success


### PR DESCRIPTION
For ease of use for customers rather than exporting the generated typescript type BrokenLinksResultV1_BrokenLinkCheckerOptions from the proto I am redeclaring the interface as BrokenLinkCheckerOptions, which will be exported to public.

One of the primary reasons for this is that I want to make all fields except origin_url optional, however I cannot use the "optional" keyword as freely in the proto for large Google style reasons. 

The changes are relatively simple except that figuring out how to convert translate per_link_options from one type to the other is tricky.