### PR TITLE
chore: Previous release please yml didnt use manifest

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,2 @@
-releaseType: node
 handleGHRelease: true
+manifest: true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "initial-version": "0.1.0",
   "packages": {
     "packages/synthetics-sdk-api": {},
-    "packages/synthetics-sdk-mocha": {},
+    "packages/synthetics-sdk-mocha": {}
   },
   "plugins": [
     {


### PR DESCRIPTION
The initial configuration o the release please bot, yielded a PR that released an initial version of the root repository. Since we are monorepo, we need to release the sub packages only. Additionally! The release-please-config.json file had invalid content (an extra comma). 

See incorrect PR: https://github.com/GoogleCloudPlatform/synthetics-sdk-nodejs/pull/33

This change _should_ make release please to use manifest file, which _should_ make monorepo work. Let's see!