### PR TITLE
options_validity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "./packages/*"
       ],
       "devDependencies": {
+        "c8": "^8.0.1",
         "eslint": "^7.32.0",
         "gts": "^3.1.1",
         "ts-mocha": "^10.0.0",
@@ -111,6 +112,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -184,6 +191,40 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -438,6 +479,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
@@ -1196,6 +1243,73 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/c8": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.1.tgz",
+      "integrity": "sha512-EINpopxZNH1mETuI0DzRA4MZpAUH+IFiRhnmFD3vFr3vdrgxqi3VfE3KL0AIL+zDq8rC9bZqwM/VDmmoe04y7w==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^2.0.0",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "rimraf": "^3.0.2",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/c8/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/c8/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/c8/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -1485,6 +1599,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -2566,6 +2686,19 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/formidable": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
@@ -2928,6 +3061,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -3287,6 +3426,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3476,6 +3651,21 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -4809,9 +4999,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -5353,6 +5543,20 @@
         "streamx": "^2.15.0"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5746,6 +5950,20 @@
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
+      "integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/packages/synthetics-sdk-broken-links/src/broken_links.ts
+++ b/packages/synthetics-sdk-broken-links/src/broken_links.ts
@@ -51,8 +51,8 @@ export interface PerLinkOption {
 }
 
 export enum LinkOrder {
-  'FIRST_N',
-  'RANDOM',
+  FIRST_N = 'FIRST_N',
+  RANDOM = 'RANDOM',
 }
 
 export enum StatusClass {

--- a/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
@@ -30,6 +30,7 @@ import {
   setDefaultOptions,
   shouldGoToBlankPage,
   createSyntheticResult,
+  validateInputOptions,
 } from '../../src/link_utils';
 
 describe('GCM Synthetics Broken Links Utilies', async () => {
@@ -131,6 +132,319 @@ describe('GCM Synthetics Broken Links Utilies', async () => {
       },
     };
     expect(options.per_link_options).to.deep.equal(link_options);
+  });
+
+  describe('validateInputOptions', () => {
+    it('throws error if origin_url is missing', () => {
+      const options = {} as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(Error, 'Missing origin_url in options');
+    });
+    it('throws error if origin_url does not start with http', () => {
+      const options = { origin_url: 'blah' } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(Error, 'origin_url must start with `http`');
+    });
+    it('throws error if link_limit is not a number', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        link_limit: 'invalid',
+      } as any as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid link_limit value, must be a number greater than 0'
+      );
+    });
+    it('throws error if link_limit is less than 1', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        link_limit: 0,
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid link_limit value, must be a number greater than 0'
+      );
+    });
+    it('throws error if query_selector_all is not a string', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        query_selector_all: 123,
+      } as any as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid query_selector_all value, must be a non-empty string'
+      );
+    });
+    it('throws error if query_selector_all is an empty string', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        query_selector_all: '',
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid query_selector_all value, must be a non-empty string'
+      );
+    });
+    it('throws error if get_attributes is not an array of strings', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        get_attributes: ['href', 123],
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid get_attributes value, must be an array of only strings'
+      );
+    });
+    it('throws error if link_order is not a valid LinkOrder value', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        link_order: 'invalid',
+      } as any as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid link_order value, must be `FIRST_N` or `RANDOM`'
+      );
+    });
+    it('link_order accepts string', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        link_order: 'RANDOM',
+      } as any as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.not.throw();
+    });
+    it('throws error if link_timeout_millis is not a number', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        link_timeout_millis: 'invalid',
+      } as any as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid link_timeout_millis value, must be a number greater than 0'
+      );
+    });
+    it('throws error if link_timeout_millis is less than 1', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        link_timeout_millis: 0,
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid link_timeout_millis value, must be a number greater than 0'
+      );
+    });
+    it('throws error if max_retries is not a number', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        max_retries: 'invalid',
+      } as any as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid max_retries value, must be a number greater than -1'
+      );
+    });
+    it('throws error if max_retries is less than -1', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        max_retries: -2,
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid max_retries value, must be a number greater than -1'
+      );
+    });
+    it('throws error if max_redirects is not a number', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        max_redirects: 'invalid',
+      } as any as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(Error, 'Invalid max_redirects');
+    });
+    it('throws error if max_redirects is less than -1', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        max_redirects: -2,
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid max_redirects value, must be a number greater than -1'
+      );
+    });
+    it('throws error if wait_for_selector is not a string', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        wait_for_selector: 123,
+      } as any as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid wait_for_selector value, must be a non-empty string'
+      );
+    });
+    it('throws error if wait_for_selector is an empty string', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        wait_for_selector: '',
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid wait_for_selector value, must be a non-empty string'
+      );
+    });
+    it('throws error if per_link_options contains an invalid URL', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        per_link_options: {
+          'invalid-url': {
+            link_timeout_millis: 5000,
+          },
+        },
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid url in per_link_options, urls must start with `http`'
+      );
+    });
+    it('throws error if per_link_options contains an invalid link_timeout_millis value', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        per_link_options: {
+          'http://example.com': {
+            link_timeout_millis: -1,
+          },
+        },
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid link_timeout_millis value in per_link_options set for http://example.com, must be a number greater than 0'
+      );
+    });
+    it('throws error if per_link_options contains an invalid expected_status_code number', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        per_link_options: {
+          'http://example.com': {
+            expected_status_code: 50,
+          },
+        },
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid expected_status_code in per_link_options for http://example.com, must be a number between 100 and 599 (inclusive) or a string present in StatusClass enum'
+      );
+    });
+    it('throws error if per_link_options contains an invalid expected_status_code string', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        per_link_options: {
+          'http://example.com': {
+            expected_status_code: 'STATUS_CLASS_WOOHOO',
+          },
+        },
+      } as any as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid expected_status_code in per_link_options for http://example.com, must be a number between 100 and 599 (inclusive) or a string present in StatusClass enum'
+      );
+    });
+    it('per_link_options accepts valid string as StatusClass', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        per_link_options: {
+          'http://example.com': {
+            expected_status_code: 'STATUS_CLASS_4XX',
+          },
+        },
+      } as any as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.not.throw();
+    });
+    it('validates input options when all values are valid', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        link_limit: 10,
+        query_selector_all: 'a',
+        get_attributes: ['href'],
+        link_order: LinkOrder.FIRST_N,
+        link_timeout_millis: 5000,
+        max_retries: 3,
+        max_redirects: 5,
+        wait_for_selector: 'a.link',
+        per_link_options: {
+          'http://example.com': {
+            link_timeout_millis: 3000,
+            expected_status_code: StatusClass.STATUS_CLASS_2XX,
+          },
+        },
+      } as BrokenLinkCheckerOptions;
+
+      expect(() => {
+        validateInputOptions(options);
+      }).not.to.throw();
+    });
+    it('validates input options and gets rid of extra fields', () => {
+      const options = {
+        origin_url: 'http://example.com',
+        fake_field: 'hello',
+      } as any as BrokenLinkCheckerOptions;
+
+      const expectations = {
+        origin_url: 'http://example.com',
+        link_limit: undefined,
+        query_selector_all: undefined,
+        get_attributes: undefined,
+        link_order: undefined,
+        link_timeout_millis: undefined,
+        max_retries: undefined,
+        max_redirects: undefined,
+        wait_for_selector: undefined,
+        per_link_options: undefined,
+      } as BrokenLinkCheckerOptions;
+
+      expect(() => {
+        validateInputOptions(options);
+      }).not.to.throw();
+      expect(validateInputOptions(options)).to.deep.equal(expectations);
+    });
   });
 
   describe('shouldGoToBlankPage', () => {


### PR DESCRIPTION
This PR write a function that makes sure all the inputOptions are valid. 

Overall validation: 
- extra fields are filtered out from the object
- all inputOptions are valid if they are undefinied/omitted, EXCEPT origin_url

Per field validation:
- origin_url: Must be present, must start with 'http'
- link_limit: must be a number greater than 0
- query_selector_all: must be a non-empty string
- get_attributes: must be an array of strings
- link_order: must be FIRST_N or RANDOM from LinkOrder enum `OR` can be a string of either of those (for js compatibility)
- link_timeout_millis: must be a number greater than 0
- max_retries: must be a number greater than -1
- max_redirects: must be a number greater than -1
- wait_for_selector: must be a non-empty string
- per_link_options:
        key -- url: must be a string that starts with 'http'
        value --
                     link_timeout_millis: must be a number greater than 0
                     expected_status_code: must be a number between 100 and 599 inclusive `OR` part of the StatusClass 
                                                              Enum or corresponding string (for js compatibility)