### PR TITLE
chore: Separates npm publish commands in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://wombat-dressing-room.appspot.com/'
-      - run: npm publish --workspaces
+      - run: npm publish --workspace packages/synthetics-sdk-api/ || npm publish --workspace packages/synthetics-sdk-mocha/
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
Background: When you postfix a command in npm with `--workspaces`, it runs that command in each package, and if it fails at any step, the whold step stops. So if you're trying to run npm run test --workspaces, and you have 5 packages, if the tests fail at package 3, tests in 4 and 5 wont run.

This is problematic with this workflow in that we're only publishing one package at a time. This means that if when running through each package running `npm publish` fails, then it wont try the next one. The failure that we're particularly concerned with is when there is no update to the package, and you get a 403 back. 

This change runs npm publish in each package individually, as separated by `||`, so that it runs until one package has been published. 