### PR TITLE
integration tests

### DIFF
--- a/packages/synthetics-sdk-broken-links/package.json
+++ b/packages/synthetics-sdk-broken-links/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "synthetics-sdk-broken-links",
+  "name": "@google-cloud/synthetics-sdk-broken-links",
   "version": "0.1.0",
   "description": "",
   "main": "./build/src/index.js",
@@ -33,7 +33,8 @@
     "chai-exclude": "^2.1.0",
     "express": "^4.18.2",
     "sinon": "^15.2.0",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "synthetics-sdk-broken-links": "file:./"
   },
   "engines": {
     "node": ">=18"

--- a/packages/synthetics-sdk-broken-links/src/broken_links.ts
+++ b/packages/synthetics-sdk-broken-links/src/broken_links.ts
@@ -16,6 +16,7 @@ import puppeteer, { Browser, Page } from 'puppeteer';
 import {
   BrokenLinksResultV1_BrokenLinkCheckerOptions,
   BrokenLinksResultV1_SyntheticLinkResult,
+  instantiateMetadata,
   getRuntimeMetadata,
   SyntheticResult,
 } from '@google-cloud/synthetics-sdk-api';
@@ -67,6 +68,9 @@ export enum StatusClass {
   STATUS_CLASS_5XX = 'STATUS_CLASS_5XX',
   STATUS_CLASS_ANY = 'STATUS_CLASS_ANY',
 }
+
+const synthetics_sdk_broken_links_package = require('../package.json');
+instantiateMetadata(synthetics_sdk_broken_links_package);
 
 export async function runBrokenLinks(
   inputOptions: BrokenLinkCheckerOptions

--- a/packages/synthetics-sdk-broken-links/src/handlers.ts
+++ b/packages/synthetics-sdk-broken-links/src/handlers.ts
@@ -23,7 +23,7 @@ import { Request, Response } from 'express';
  * @returns ExpressJS compatible middleware that invokes SyntheticsSDK broken links, and
  * returns the results via res.send
  */
-export function runBrokenLinkHandler(options: BrokenLinkCheckerOptions) {
+export function runBrokenLinksHandler(options: BrokenLinkCheckerOptions) {
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   return async (req: Request, res: Response): Promise<any> =>
     res.send(await runBrokenLinks(options));

--- a/packages/synthetics-sdk-broken-links/src/navigation_func.ts
+++ b/packages/synthetics-sdk-broken-links/src/navigation_func.ts
@@ -174,7 +174,7 @@ export async function checkLink(
 
   const response = isHTTPResponse(responseOrError)
     ? (responseOrError as HTTPResponse)
-    : null;
+    : undefined;
 
   return {
     link_passed: passed,

--- a/packages/synthetics-sdk-broken-links/test/example_html_files/integration_server.js
+++ b/packages/synthetics-sdk-broken-links/test/example_html_files/integration_server.js
@@ -1,0 +1,67 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const functions = require('@google-cloud/functions-framework');
+const SyntheticsSdkBrokenLinks = require('synthetics-sdk-broken-links');
+const path = require('path');
+
+/*
+ * This is the server template that is required to run a synthetic monitor in
+ * Google Cloud Functions.
+ */
+
+// Handles error when trying to visit page that does not exist
+functions.http('BrokenLinksPageDoesNotExist', SyntheticsSdkBrokenLinks.runBrokenLinksHandler({
+  origin_url: `file:${path.join(
+    __dirname,
+    '../example_html_files/file_doesnt_exist.html'
+  )}`
+}));
+
+// Visits and checks empty page with no links
+functions.http('BrokenLinksEmptyPageOk', SyntheticsSdkBrokenLinks.runBrokenLinksHandler({
+  origin_url: `file:${path.join(
+    __dirname,
+    '../example_html_files/200.html'
+  )}`
+}));
+
+// Exits early when options cannot be parsed
+functions.http('BrokenLinksInvalidOptionsNotOk', SyntheticsSdkBrokenLinks.runBrokenLinksHandler({
+  origin_url: `file:${path.join(
+    __dirname,
+    '../example_html_files/retrieve_links_test.html'
+  )}`,
+  link_order: 'incorrect'
+}));
+
+// Completes full failing execution
+functions.http('BrokenLinksFailingOk', SyntheticsSdkBrokenLinks.runBrokenLinksHandler({
+  origin_url: `file:${path.join(
+    __dirname,
+    '../example_html_files/retrieve_links_test.html'
+  )}`,
+  query_selector_all: 'a[src], img[href]',
+  get_attributes: ['href', 'src']
+}));
+
+// Completes full passing execution
+functions.http('BrokenLinksPassingOk', SyntheticsSdkBrokenLinks.runBrokenLinksHandler({
+  origin_url: `file:${path.join(
+    __dirname,
+    '../example_html_files/retrieve_links_test.html'
+  )}`,
+  query_selector_all: 'a[src]',
+  get_attributes: ['src']
+}));

--- a/packages/synthetics-sdk-broken-links/test/integration/integration.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/integration/integration.spec.ts
@@ -1,0 +1,418 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  ResponseStatusCode_StatusClass,
+  BrokenLinksResultV1_BrokenLinkCheckerOptions_LinkOrder,
+  SyntheticResult,
+} from '@google-cloud/synthetics-sdk-api';
+
+import { expect } from 'chai';
+import supertest from 'supertest';
+const path = require('path');
+
+require('../../test/example_html_files/integration_server.js');
+const { getTestServer } = require('@google-cloud/functions-framework/testing');
+
+describe('CloudFunctionV2 Running Broken Link Synthetics', async () => {
+  const status_class_2xx = {
+    status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_2XX,
+  };
+
+  it('Handles error when trying to visit page that does not exist', async () => {
+    const server = getTestServer('BrokenLinksPageDoesNotExist');
+
+    // invoke SyntheticBrokenLinks with SuperTest
+    const response = await supertest(server)
+      .get('/')
+      .send()
+      .set('Content-Type', 'application/json')
+      .expect(200);
+
+    const output: SyntheticResult = response.body as SyntheticResult;
+    const start_time = output.start_time;
+    const end_time = output.end_time;
+    const broken_links_result = output?.synthetic_broken_links_result_v1;
+    const origin_link = broken_links_result?.origin_link_result;
+    const followed_links = broken_links_result?.followed_link_results;
+    const runtime_metadata = output?.runtime_metadata;
+
+    expect(start_time).to.be.a.string;
+    expect(end_time).to.be.a.string;
+
+    expect(broken_links_result?.link_count).to.equal(1);
+    expect(broken_links_result?.passing_link_count).to.equal(0);
+    expect(broken_links_result?.failing_link_count).to.equal(1);
+    expect(broken_links_result?.unreachable_count).to.equal(1);
+    expect(broken_links_result?.status_2xx_count).to.equal(0);
+    expect(broken_links_result?.status_3xx_count).to.equal(0);
+    expect(broken_links_result?.status_4xx_count).to.equal(0);
+    expect(broken_links_result?.status_5xx_count).to.equal(0);
+
+    const origin_url = `file:${path.join(
+      __dirname,
+      '../example_html_files/file_doesnt_exist.html'
+    )}`;
+
+    expect(origin_link)
+      .excluding(['link_start_time', 'link_end_time'])
+      .to.deep.equal({
+        link_passed: false,
+        expected_status_code: status_class_2xx,
+        origin_url: origin_url,
+        target_url: origin_url,
+        html_element: '',
+        anchor_text: '',
+        error_type: 'Error',
+        error_message: 'net::ERR_FILE_NOT_FOUND at ' + origin_url,
+        link_start_time: 'NA',
+        link_end_time: 'NA',
+        is_origin: true,
+      });
+
+    expect(followed_links).to.deep.equal([]);
+
+    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-api']).to.not.be
+      .undefined;
+    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-broken-links']).to
+      .not.be.undefined;
+  });
+
+  it('Visits and checks empty page with no links', async () => {
+    const server = getTestServer('BrokenLinksEmptyPageOk');
+
+    // invoke SyntheticBrokenLinks with SuperTest
+    const response = await supertest(server)
+      .get('/')
+      .send()
+      .set('Content-Type', 'application/json')
+      .expect(200);
+
+    const origin_url = `file:${path.join(
+      __dirname,
+      '../example_html_files/200.html'
+    )}`;
+
+    const output: SyntheticResult = response.body as SyntheticResult;
+    const start_time = output.start_time;
+    const end_time = output.end_time;
+    const broken_links_result = output?.synthetic_broken_links_result_v1;
+    const options = broken_links_result?.options;
+    const origin_link = broken_links_result?.origin_link_result;
+    const followed_links = broken_links_result?.followed_link_results;
+    const runtime_metadata = output?.runtime_metadata;
+
+    expect(start_time).to.be.a.string;
+    expect(end_time).to.be.a.string;
+
+    expect(broken_links_result?.link_count).to.equal(1);
+    expect(broken_links_result?.passing_link_count).to.equal(1);
+    expect(broken_links_result?.failing_link_count).to.equal(0);
+    expect(broken_links_result?.unreachable_count).to.equal(0);
+    expect(broken_links_result?.status_2xx_count).to.equal(1);
+    expect(broken_links_result?.status_3xx_count).to.equal(0);
+    expect(broken_links_result?.status_4xx_count).to.equal(0);
+    expect(broken_links_result?.status_5xx_count).to.equal(0);
+
+    expect(options).to.deep.equal({
+      origin_url: origin_url,
+      link_limit: 50,
+      query_selector_all: 'a',
+      get_attributes: ['href'],
+      link_order:
+        BrokenLinksResultV1_BrokenLinkCheckerOptions_LinkOrder.FIRST_N,
+      link_timeout_millis: 30000,
+      max_retries: 0,
+      max_redirects: Number.MAX_SAFE_INTEGER,
+      wait_for_selector: '',
+      per_link_options: {},
+    });
+
+    expect(origin_link)
+      .excluding(['link_start_time', 'link_end_time'])
+      .to.deep.equal({
+        link_passed: true,
+        expected_status_code: status_class_2xx,
+        origin_url: origin_url,
+        target_url: origin_url,
+        html_element: '',
+        anchor_text: '',
+        status_code: 200,
+        error_type: '',
+        error_message: '',
+        link_start_time: 'NA',
+        link_end_time: 'NA',
+        is_origin: true,
+      });
+
+    expect(followed_links).to.deep.equal([]);
+
+    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-api']).to.not.be
+      .undefined;
+    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-broken-links']).to
+      .not.be.undefined;
+  });
+
+  it('Exits early with generic_result when options cannot be parsed', async () => {
+    const server = getTestServer('BrokenLinksInvalidOptionsNotOk');
+
+    // invoke SyntheticBrokenLinks with SuperTest
+    const response = await supertest(server)
+      .get('/')
+      .send()
+      .set('Content-Type', 'application/json')
+      .expect(200);
+
+    const output: SyntheticResult = response.body as SyntheticResult;
+    const start_time = output.start_time;
+    const end_time = output.end_time;
+    const synthetic_generic_result = output?.synthetic_generic_result_v1;
+    const runtime_metadata = output?.runtime_metadata;
+
+    expect(synthetic_generic_result?.ok).to.be.false;
+    expect(synthetic_generic_result?.generic_error?.error_type).to.equal(
+      'Error'
+    );
+    expect(synthetic_generic_result?.generic_error?.error_message).to.equal(
+      'Invalid link_order value, must be `FIRST_N` or `RANDOM`'
+    );
+    expect(start_time).to.be.a.string;
+    expect(end_time).to.be.a.string;
+
+    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-api']).to.not.be
+      .undefined;
+    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-broken-links']).to
+      .not.be.undefined;
+  });
+
+  it('Runs a failing Broken Links suite', async () => {
+    const server = getTestServer('BrokenLinksFailingOk');
+
+    // invoke SyntheticBrokenLinks with SuperTest
+    const response = await supertest(server)
+      .get('/')
+      .send()
+      .set('Content-Type', 'application/json')
+      .expect(200);
+
+    const origin_url = `file:${path.join(
+      __dirname,
+      '../example_html_files/retrieve_links_test.html'
+    )}`;
+
+    const output: SyntheticResult = response.body as SyntheticResult;
+    const start_time = output.start_time;
+    const end_time = output.end_time;
+    const broken_links_result = output?.synthetic_broken_links_result_v1;
+    const options = broken_links_result?.options;
+    const origin_link = broken_links_result?.origin_link_result;
+    const followed_links = broken_links_result?.followed_link_results;
+    const runtime_metadata = output?.runtime_metadata;
+
+    expect(start_time).to.be.a.string;
+    expect(end_time).to.be.a.string;
+
+    expect(broken_links_result?.link_count).to.equal(3);
+    expect(broken_links_result?.passing_link_count).to.equal(2);
+    expect(broken_links_result?.failing_link_count).to.equal(1);
+    expect(broken_links_result?.unreachable_count).to.equal(1);
+    expect(broken_links_result?.status_2xx_count).to.equal(2);
+    expect(broken_links_result?.status_3xx_count).to.equal(0);
+    expect(broken_links_result?.status_4xx_count).to.equal(0);
+    expect(broken_links_result?.status_5xx_count).to.equal(0);
+
+    expect(options).to.deep.equal({
+      origin_url: origin_url,
+      link_limit: 50,
+      query_selector_all: 'a[src], img[href]',
+      get_attributes: ['href', 'src'],
+      link_order:
+        BrokenLinksResultV1_BrokenLinkCheckerOptions_LinkOrder.FIRST_N,
+      link_timeout_millis: 30000,
+      max_retries: 0,
+      max_redirects: Number.MAX_SAFE_INTEGER,
+      wait_for_selector: '',
+      per_link_options: {},
+    });
+
+    expect(origin_link)
+      .excluding(['link_start_time', 'link_end_time'])
+      .to.deep.equal({
+        link_passed: true,
+        expected_status_code: status_class_2xx,
+        origin_url: origin_url,
+        target_url: origin_url,
+        html_element: '',
+        anchor_text: '',
+        status_code: 200,
+        error_type: '',
+        error_message: '',
+        link_start_time: 'NA',
+        link_end_time: 'NA',
+        is_origin: true,
+      });
+
+    const sorted_followed_links = followed_links?.sort((a, b) =>
+      a.target_url.localeCompare(b.target_url)
+    );
+
+    const doesnt_exist_path = `file://${path.join(
+      __dirname,
+      '../example_html_files/file_doesnt_exist.html'
+    )}`
+      .split(' ')
+      .join('%20');
+    expect(sorted_followed_links)
+      .excluding(['target_url', 'link_start_time', 'link_end_time'])
+      .to.deep.equal([
+        {
+          link_passed: true,
+          expected_status_code: status_class_2xx,
+          origin_url: origin_url,
+          target_url: 'CHECKED_BELOW',
+          html_element: 'a',
+          anchor_text: 'External Link',
+          status_code: 200,
+          error_type: '',
+          error_message: '',
+          link_start_time: 'NA',
+          link_end_time: 'NA',
+          is_origin: false,
+        },
+        {
+          link_passed: false,
+          expected_status_code: { status_class: 200 },
+          origin_url: origin_url,
+          target_url: 'CHECKED_BELOW',
+          html_element: 'img',
+          anchor_text: '',
+          error_type: 'Error',
+          error_message: 'net::ERR_FILE_NOT_FOUND at ' + doesnt_exist_path,
+          link_start_time: 'NA',
+          link_end_time: 'NA',
+          is_origin: false,
+        },
+      ]);
+
+    const expectedTargetPaths = [
+      'example_html_files/200.html',
+      'example_html_files/file_doesnt_exist.html',
+    ];
+    followed_links?.forEach((link, index) => {
+      expect(link.target_url.endsWith(expectedTargetPaths[index]));
+    });
+
+    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-api']).to.not.be
+      .undefined;
+    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-broken-links']).to
+      .not.be.undefined;
+  });
+
+  it('Runs a passing Broken Links suite', async () => {
+    const server = getTestServer('BrokenLinksPassingOk');
+
+    // invoke SyntheticBrokenLinks with SuperTest
+    const response = await supertest(server)
+      .get('/')
+      .send()
+      .set('Content-Type', 'application/json')
+      .expect(200);
+
+    const origin_url = `file:${path.join(
+      __dirname,
+      '../example_html_files/retrieve_links_test.html'
+    )}`;
+
+    const output: SyntheticResult = response.body as SyntheticResult;
+    const start_time = output.start_time;
+    const end_time = output.end_time;
+    const broken_links_result = output?.synthetic_broken_links_result_v1;
+    const options = broken_links_result?.options;
+    const origin_link = broken_links_result?.origin_link_result;
+    const followed_links = broken_links_result?.followed_link_results;
+    const runtime_metadata = output?.runtime_metadata;
+
+    expect(start_time).to.be.a.string;
+    expect(end_time).to.be.a.string;
+
+    expect(broken_links_result?.link_count).to.equal(2);
+    expect(broken_links_result?.passing_link_count).to.equal(2);
+    expect(broken_links_result?.failing_link_count).to.equal(0);
+    expect(broken_links_result?.unreachable_count).to.equal(0);
+    expect(broken_links_result?.status_2xx_count).to.equal(2);
+    expect(broken_links_result?.status_3xx_count).to.equal(0);
+    expect(broken_links_result?.status_4xx_count).to.equal(0);
+    expect(broken_links_result?.status_5xx_count).to.equal(0);
+
+    expect(options).to.deep.equal({
+      origin_url: origin_url,
+      link_limit: 50,
+      query_selector_all: 'a[src]',
+      get_attributes: ['src'],
+      link_order:
+        BrokenLinksResultV1_BrokenLinkCheckerOptions_LinkOrder.FIRST_N,
+      link_timeout_millis: 30000,
+      max_retries: 0,
+      max_redirects: Number.MAX_SAFE_INTEGER,
+      wait_for_selector: '',
+      per_link_options: {},
+    });
+
+    expect(origin_link)
+      .excluding(['link_start_time', 'link_end_time'])
+      .to.deep.equal({
+        link_passed: true,
+        expected_status_code: status_class_2xx,
+        origin_url: origin_url,
+        target_url: origin_url,
+        html_element: '',
+        anchor_text: '',
+        status_code: 200,
+        error_type: '',
+        error_message: '',
+        link_start_time: 'NA',
+        link_end_time: 'NA',
+        is_origin: true,
+      });
+
+    expect(followed_links)
+      .excluding(['target_url', 'link_start_time', 'link_end_time'])
+      .to.deep.equal([
+        {
+          link_passed: true,
+          expected_status_code: status_class_2xx,
+          origin_url: origin_url,
+          target_url: 'CHECKED_BELOW',
+          html_element: 'a',
+          anchor_text: 'External Link',
+          status_code: 200,
+          error_type: '',
+          error_message: '',
+          link_start_time: 'NA',
+          link_end_time: 'NA',
+          is_origin: false,
+        },
+      ]);
+
+    const expectedTargetPaths = ['example_html_files/200.html'];
+    followed_links?.forEach((link, index) => {
+      expect(link.target_url.endsWith(expectedTargetPaths[index]));
+    });
+
+    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-api']).to.not.be
+      .undefined;
+    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-broken-links']).to
+      .not.be.undefined;
+  });
+});

--- a/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
@@ -131,7 +131,9 @@ describe('runBrokenLinks', async () => {
     const file_doesnt_exist_path = `file://${path.join(
       __dirname,
       '../example_html_files/file_doesnt_exist.html'
-    )}`.split(' ').join('%20');
+    )}`
+      .split(' ')
+      .join('%20');
     const expectedFollowedLinksResults: BrokenLinksResultV1_SyntheticLinkResult[] =
       [
         {
@@ -161,7 +163,7 @@ describe('runBrokenLinks', async () => {
           link_start_time: 'NA',
           link_end_time: 'NA',
           is_origin: false,
-        }
+        },
       ];
 
     const broken_links_result = result.synthetic_broken_links_result_v1;


### PR DESCRIPTION
The integration tests test the following scenario:
- Handles error when trying to visit page that does not exist
- Visits and checks empty page with no links
- Exits early when options cannot be parsed
- Completes full failing execution
- Completes full passing execution

Other changes
- instantiate metdata in `broken_links.ts`
- fix name in package.json