### PR TITLE
implement logic to limit redirects to options.max_redirects

### DIFF
--- a/packages/synthetics-sdk-broken-links/src/options_func.ts
+++ b/packages/synthetics-sdk-broken-links/src/options_func.ts
@@ -87,10 +87,10 @@ export function validateInputOptions(inputOptions: BrokenLinkCheckerOptions) {
   if (
     inputOptions.link_timeout_millis !== undefined &&
     (typeof inputOptions.link_timeout_millis !== 'number' ||
-      inputOptions.link_timeout_millis < 1)
+      inputOptions.link_timeout_millis < 9)
   ) {
     throw new Error(
-      'Invalid link_timeout_millis value, must be a number greater than 0'
+      'Invalid link_timeout_millis value, must be a number greater than 9'
     );
   }
 
@@ -142,10 +142,10 @@ export function validateInputOptions(inputOptions: BrokenLinkCheckerOptions) {
     if (
       value.link_timeout_millis !== undefined &&
       (typeof inputOptions.link_timeout_millis !== 'number' ||
-        inputOptions.link_timeout_millis < 1)
+        inputOptions.link_timeout_millis < 9)
     ) {
       throw new Error(
-        `Invalid link_timeout_millis value in per_link_options set for ${key}, must be a number greater than 0`
+        `Invalid link_timeout_millis value in per_link_options set for ${key}, must be a number greater than 9`
       );
     }
 

--- a/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
@@ -43,7 +43,7 @@ describe('runBrokenLinks', async () => {
       syntheticResult.synthetic_broken_links_result_v1;
     expect(broken_links_result?.origin_link_result?.link_passed).to.be.false;
     expect(broken_links_result?.followed_link_results?.length).to.equal(0);
-  }).timeout(10000);
+  }).timeout(15000);
 
   it('returns generic_result with appropriate error information if error thrown', async () => {
     const inputOptions: BrokenLinkCheckerOptions = {
@@ -59,7 +59,7 @@ describe('runBrokenLinks', async () => {
     expect(genericResult?.generic_error?.error_message).to.equal(
       'origin_uri must be a string that starts with `http`'
     );
-  }).timeout(10000);
+  }).timeout(15000);
 
   it('returns broken_links_result with origin link failure when waitForSelector exceeds deadline', async () => {
     const origin_uri = `file:${path.join(
@@ -84,7 +84,7 @@ describe('runBrokenLinks', async () => {
     expect(origin_link?.error_message).to.equal(
       'Waiting for selector `not_present` failed: Waiting failed: 3001ms exceeded'
     );
-  }).timeout(10000);
+  }).timeout(15000);
 
   it('successful execution with 1 failing link', async () => {
     const origin_uri = `file:${path.join(
@@ -200,5 +200,5 @@ describe('runBrokenLinks', async () => {
     broken_links_result?.followed_link_results?.forEach((link, index) => {
       expect(link.target_uri.endsWith(expectedTargeturis[index]));
     });
-  }).timeout(10000);
+  }).timeout(150000);
 });

--- a/packages/synthetics-sdk-broken-links/test/unit/options_func.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/options_func.spec.ts
@@ -204,7 +204,7 @@ describe('GCM Synthetics Broken Links  options_func suite testing', () => {
         validateInputOptions(options);
       }).to.throw(
         Error,
-        'Invalid link_timeout_millis value, must be a number greater than 0'
+        'Invalid link_timeout_millis value, must be a number greater than 9'
       );
     });
     it('throws error if link_timeout_millis is less than 1', () => {
@@ -216,7 +216,7 @@ describe('GCM Synthetics Broken Links  options_func suite testing', () => {
         validateInputOptions(options);
       }).to.throw(
         Error,
-        'Invalid link_timeout_millis value, must be a number greater than 0'
+        'Invalid link_timeout_millis value, must be a number greater than 9'
       );
     });
     it('throws error if max_retries is not a number', () => {
@@ -317,7 +317,7 @@ describe('GCM Synthetics Broken Links  options_func suite testing', () => {
         validateInputOptions(options);
       }).to.throw(
         Error,
-        'Invalid link_timeout_millis value in per_link_options set for http://example.com, must be a number greater than 0'
+        'Invalid link_timeout_millis value in per_link_options set for http://example.com, must be a number greater than 9'
       );
     });
     it('throws error if per_link_options contains an invalid expected_status_code number', () => {


### PR DESCRIPTION
Limits the number of redirects on a per to max_redirects

Also changes minimum max_timeout_millis to be 10ms since when the timeout is less than that sometimes it causes the page.on('request') call to hang.