### PR TITLE
fix redirect function

### DIFF
--- a/packages/synthetics-sdk-broken-links/src/navigation_func.ts
+++ b/packages/synthetics-sdk-broken-links/src/navigation_func.ts
@@ -284,7 +284,11 @@ async function fetchLink(
     let followedRedirects = 0;
     // Intercept requests and follow redirects until the maximum number of redirects is reached.
     page.on('request', async (request) => {
-     followedRedirects = await handleNavigationRequestWithRedirects(request, max_redirects, followedRedirects);
+      followedRedirects = await handleNavigationRequestWithRedirects(
+        request,
+        max_redirects,
+        followedRedirects
+      );
     });
 
     responseOrError = await page.goto(target_uri, {
@@ -311,7 +315,7 @@ async function fetchLink(
 export async function handleNavigationRequestWithRedirects(
   request: HTTPRequest,
   max_redirects: number,
-  followedRedirects: number,
+  followedRedirects: number
 ) {
   if (request.isNavigationRequest()) {
     if (followedRedirects > max_redirects) {

--- a/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
@@ -201,4 +201,18 @@ describe('runBrokenLinks', async () => {
       expect(link.target_uri.endsWith(expectedTargeturis[index]));
     });
   }).timeout(150000);
+
+  it.only('Wikipedia', async () => {
+    const inputOptions = {
+      // origin_uri: 'http://gooogle.com',
+      origin_uri: 'http://crappyschool.com',
+      query_selector_all: 'a',
+      get_attributes: ['href'],
+      link_limit: 1,
+      max_redirects: 1,
+    };
+
+    const result = await runBrokenLinks(inputOptions);
+    console.log('results:\n', result);
+  }).timeout(70000);
 });

--- a/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
@@ -204,12 +204,12 @@ describe('runBrokenLinks', async () => {
 
   it.only('Wikipedia', async () => {
     const inputOptions = {
-      // origin_uri: 'http://gooogle.com',
-      origin_uri: 'http://crappyschool.com',
+      origin_uri: 'http://gooogle.com',
+      // origin_uri: 'http://crappyschool.com',
       query_selector_all: 'a',
       get_attributes: ['href'],
       link_limit: 1,
-      max_redirects: 1,
+      max_redirects: 0,
     };
 
     const result = await runBrokenLinks(inputOptions);

--- a/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
@@ -201,18 +201,4 @@ describe('runBrokenLinks', async () => {
       expect(link.target_uri.endsWith(expectedTargeturis[index]));
     });
   }).timeout(150000);
-
-  it.only('Wikipedia', async () => {
-    const inputOptions = {
-      origin_uri: 'http://gooogle.com',
-      // origin_uri: 'http://crappyschool.com',
-      query_selector_all: 'a',
-      get_attributes: ['href'],
-      link_limit: 1,
-      max_redirects: 0,
-    };
-
-    const result = await runBrokenLinks(inputOptions);
-    console.log('results:\n', result);
-  }).timeout(70000);
 });

--- a/packages/synthetics-sdk-broken-links/test/unit/navigation_func.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/navigation_func.spec.ts
@@ -298,13 +298,16 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
         continue: async () => {},
       } as HTTPRequest;
       const max_redirects = 3;
+      let followedRedirects = 0;
 
       // spy on continue() call
       const continueSpy = sinon.spy(request, 'continue');
 
-      await handleNavigationRequestWithRedirects(request, max_redirects);
+      followedRedirects = await handleNavigationRequestWithRedirects(request, max_redirects, followedRedirects);
 
       expect(continueSpy.calledOnce).to.be.true;
+      expect(followedRedirects).to.equal(1);
+
     });
 
     it('should continue navigation request is not a navigationResut()', async () => {
@@ -313,13 +316,15 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
         continue: async () => {},
       } as HTTPRequest;
       const max_redirects = 3;
+      let followedRedirects = 0;
 
       // spy on continue() call
       const continueSpy = sinon.spy(request, 'continue');
 
-      await handleNavigationRequestWithRedirects(request, max_redirects);
+      followedRedirects = await handleNavigationRequestWithRedirects(request, max_redirects, followedRedirects);
 
       expect(continueSpy.calledOnce).to.be.true;
+      expect(followedRedirects).to.equal(1);
     });
 
     it('should abort navigation request if redirects count is more than max_redirects', async () => {
@@ -329,12 +334,14 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
         abort: async () => {},
       } as HTTPRequest;
       const max_redirects = -1;
+      let followedRedirects = 0;
 
       const continueSpy = sinon.spy(request, 'abort');
 
-      await handleNavigationRequestWithRedirects(request, max_redirects);
+      followedRedirects = await handleNavigationRequestWithRedirects(request, max_redirects, followedRedirects);
 
       expect(continueSpy.calledOnce).to.be.true;
+      expect(followedRedirects).to.equal(0);
     });
   });
 });

--- a/packages/synthetics-sdk-broken-links/test/unit/navigation_func.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/navigation_func.spec.ts
@@ -303,14 +303,17 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
       // spy on continue() call
       const continueSpy = sinon.spy(request, 'continue');
 
-      followedRedirects = await handleNavigationRequestWithRedirects(request, max_redirects, followedRedirects);
+      followedRedirects = await handleNavigationRequestWithRedirects(
+        request,
+        max_redirects,
+        followedRedirects
+      );
 
       expect(continueSpy.calledOnce).to.be.true;
       expect(followedRedirects).to.equal(1);
-
     });
 
-    it('should continue navigation request is not a navigationResut()', async () => {
+    it('should continue navigation request if is not a navigationResut()', async () => {
       const request = {
         isNavigationRequest: () => false,
         continue: async () => {},
@@ -321,10 +324,14 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
       // spy on continue() call
       const continueSpy = sinon.spy(request, 'continue');
 
-      followedRedirects = await handleNavigationRequestWithRedirects(request, max_redirects, followedRedirects);
+      followedRedirects = await handleNavigationRequestWithRedirects(
+        request,
+        max_redirects,
+        followedRedirects
+      );
 
       expect(continueSpy.calledOnce).to.be.true;
-      expect(followedRedirects).to.equal(1);
+      expect(followedRedirects).to.equal(0);
     });
 
     it('should abort navigation request if redirects count is more than max_redirects', async () => {
@@ -338,7 +345,11 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
 
       const continueSpy = sinon.spy(request, 'abort');
 
-      followedRedirects = await handleNavigationRequestWithRedirects(request, max_redirects, followedRedirects);
+      followedRedirects = await handleNavigationRequestWithRedirects(
+        request,
+        max_redirects,
+        followedRedirects
+      );
 
       expect(continueSpy.calledOnce).to.be.true;
       expect(followedRedirects).to.equal(0);

--- a/packages/synthetics-sdk-broken-links/test/unit/navigation_func.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/navigation_func.spec.ts
@@ -290,7 +290,7 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
     });
   });
 
-  describe('handleNavigationRequestWithRedirets', async () => {
+  /*describe('handleNavigationRequestWithRedirets', async () => {
     it('should continue navigation request if redirects count is less than max_redirects', async () => {
       // Arrange
       const request = {
@@ -381,7 +381,7 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
       expect(continueSpy.called).to.be.false;
       expect(followedRedirects).to.equal(0);
     });
-  });
+  });*/
 });
 
 describe('retrieveLinksFromPage', async () => {

--- a/packages/synthetics-sdk-broken-links/test/unit/navigation_func.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/navigation_func.spec.ts
@@ -202,8 +202,13 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
       const options_with_timeout = Object.assign({}, options);
       options_with_timeout.link_timeout_millis = 5;
 
+      const target_uri = `file:${path.join(
+        __dirname,
+        '../example_html_files/jokes.json'
+      )}`
+
       const timeout_link: LinkIntermediate = {
-        target_uri: 'https://example.com',
+        target_uri: target_uri,
         anchor_text: "Hello I'm an example",
         html_element: 'img',
       };
@@ -218,7 +223,7 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
         link_passed: false,
         expected_status_code: status_class_2xx,
         source_uri: 'http://origin.com',
-        target_uri: 'https://example.com',
+        target_uri: target_uri,
         html_element: 'img',
         anchor_text: "Hello I'm an example",
         status_code: undefined,
@@ -290,7 +295,7 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
     });
   });
 
-  /*describe('handleNavigationRequestWithRedirets', async () => {
+  describe('handleNavigationRequestWithRedirets', async () => {
     it('should continue navigation request if redirects count is less than max_redirects', async () => {
       // Arrange
       const request = {
@@ -314,7 +319,7 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
       expect(followedRedirects).to.equal(1);
     });
 
-    it('should continue navigation request if is not a navigationResut()', async () => {
+    it('should continue navigation request if is not a navigationResult()', async () => {
       const request = {
         isNavigationRequest: () => false,
         isInterceptResolutionHandled: () => false,
@@ -336,19 +341,17 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
       expect(followedRedirects).to.equal(0);
     });
 
-    it('should respond appropriately if redirects count is more than max_redirects', async () => {
+    it('should abort if redirects count is more than max_redirects', async () => {
       // Arrange
       const request = {
         isNavigationRequest: () => true,
         isInterceptResolutionHandled: () => false,
-        redirectChain: () => [{ response: () => ({ status: () => 302 }) }], // Simulate a redirect chain
-        // eslint-disable-next-line  @typescript-eslint/no-unused-vars
-        respond: ({ status, contentType, body }) => {},
+        abort: () => {},
       } as HTTPRequest;
       const max_redirects = -1;
       let followedRedirects = 0;
 
-      const continueSpy = sinon.spy(request, 'respond');
+      const continueSpy = sinon.spy(request, 'abort');
 
       followedRedirects = await handleNavigationRequestWithRedirects(
         request,
@@ -381,7 +384,7 @@ describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
       expect(continueSpy.called).to.be.false;
       expect(followedRedirects).to.equal(0);
     });
-  });*/
+  });
 });
 
 describe('retrieveLinksFromPage', async () => {


### PR DESCRIPTION
This change does 3 things:
1. Prior to any request interception or handling we need to check if it has already been handled by an unknown third-party per puppeteer documention. (change in code:  `!request.isInterceptResolutionHandled()` before any call to `request.respond()` or `request.continue()`). 

Puppeteer documentation: 
```It is therefore important to always check the resolution status using [request.isInterceptResolutionHandled](https://github.com/puppeteer/puppeteer/blob/59578d9cd5709bebe3117f8e060ad7cab220b3df/docs/api.md#httprequestisinterceptresolutionhandled) before calling abort/continue/respond.```

2.  In order to stop the navigationRequest when the number of redirects gets too large we need to keep track of the total number of redirects. I was previously initializing `followedRedircts` in `handleNavigationRequestWithRedirects` when in reality it needs to be done outside of the function.

3. We keeptrack of the last HTTPResponse received and return that rarther than a net::ABORTED