### PR TITLE
fix: Fixes broken patch dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3176,6 +3176,7 @@
       "version": "10.0.16",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.16.tgz",
       "integrity": "sha512-j2Du5SYpXZjJVJtXBokASpPRj+e2z+VUhCPHmM6WMfe3dpHu6iVKJMU6AiBcMp/XTAYnEj6Wc1trJUWwZ0QaAQ==",
+      "dev": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -3183,7 +3184,8 @@
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
-      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA=="
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
     },
     "node_modules/@types/superagent": {
       "version": "4.1.18",
@@ -9422,21 +9424,20 @@
     },
     "packages/synthetics-sdk-api": {
       "name": "@google-cloud/synthetics-sdk-api",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-cloud/opentelemetry-cloud-trace-exporter": "^2.1.0",
-        "@opentelemetry/api": "^1.6.0",
-        "@opentelemetry/auto-instrumentations-node": "^0.39.2",
-        "@opentelemetry/instrumentation": "^0.43.0",
-        "@opentelemetry/sdk-node": "^0.43.0",
-        "@opentelemetry/sdk-trace-base": "^1.17.0",
-        "@opentelemetry/sdk-trace-node": "^1.17.0",
-        "@types/sinon": "^10.0.16",
-        "error-stack-parser": "^2.1.4",
-        "google-auth-library": "^9.0.0",
-        "ts-proto": "^1.148.1",
-        "winston": "^3.10.0"
+        "@google-cloud/opentelemetry-cloud-trace-exporter": "2.1.0",
+        "@opentelemetry/api": "1.6.0",
+        "@opentelemetry/auto-instrumentations-node": "0.39.2",
+        "@opentelemetry/instrumentation": "0.43.0",
+        "@opentelemetry/sdk-node": "0.43.0",
+        "@opentelemetry/sdk-trace-base": "1.17.0",
+        "@opentelemetry/sdk-trace-node": "1.17.0",
+        "error-stack-parser": "2.1.4",
+        "google-auth-library": "9.0.0",
+        "ts-proto": "1.148.1",
+        "winston": "3.10.0"
       },
       "devDependencies": {
         "@google-cloud/functions-framework": "^3.1.1",
@@ -9445,6 +9446,7 @@
         "@types/express": "^4.17.17",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.15.10",
+        "@types/sinon": "^10.0.16",
         "@types/supertest": "^2.0.12",
         "chai": "^4.3.7",
         "express": "^4.18.2",

--- a/packages/synthetics-sdk-api/package.json
+++ b/packages/synthetics-sdk-api/package.json
@@ -12,6 +12,7 @@
     "@types/express": "^4.17.17",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.15.10",
+    "@types/sinon": "^10.0.16",
     "@types/supertest": "^2.0.12",
     "chai": "^4.3.7",
     "express": "^4.18.2",
@@ -31,18 +32,17 @@
     "posttest": "npm run lint"
   },
   "dependencies": {
-    "@google-cloud/opentelemetry-cloud-trace-exporter": "^2.1.0",
-    "@opentelemetry/api": "^1.6.0",
-    "@opentelemetry/auto-instrumentations-node": "^0.39.2",
-    "@opentelemetry/instrumentation": "^0.43.0",
-    "@opentelemetry/sdk-node": "^0.43.0",
-    "@opentelemetry/sdk-trace-base": "^1.17.0",
-    "@opentelemetry/sdk-trace-node": "^1.17.0",
-    "@types/sinon": "^10.0.16",
-    "error-stack-parser": "^2.1.4",
-    "google-auth-library": "^9.0.0",
-    "ts-proto": "^1.148.1",
-    "winston": "^3.10.0"
+    "@google-cloud/opentelemetry-cloud-trace-exporter": "2.1.0",
+    "@opentelemetry/api": "1.6.0",
+    "@opentelemetry/auto-instrumentations-node": "0.39.2",
+    "@opentelemetry/instrumentation": "0.43.0",
+    "@opentelemetry/sdk-node": "0.43.0",
+    "@opentelemetry/sdk-trace-base": "1.17.0",
+    "@opentelemetry/sdk-trace-node": "1.17.0",
+    "error-stack-parser": "2.1.4",
+    "google-auth-library": "9.0.0",
+    "ts-proto": "1.148.1",
+    "winston": "3.10.0"
   },
   "author": "Google Inc.",
   "license": "Apache-2.0"


### PR DESCRIPTION
The latest *patch* version of @opentelemetry/auto-instrumentation-node introduces a breaking change such that for newly created synthetics (no package-lock to point to old versions of @opentelemetry/auto-instrumentation-node), no traces are being written. 

This change locks all production dependencies to exact versions of dependencies, rather than the latest minor version. This is a defensive measure against developers in the OS ecosystem causing breaking changes at either the minor or patch levels.

See: generic-synthetic-nodejs w/ current version 0.3.0 of @google-cloud/synthetics-sdk-api.

![image](https://github.com/GoogleCloudPlatform/synthetics-sdk-nodejs/assets/66844903/5737fdd5-e867-4f33-8de3-cc41c111b597)

See: generic-synthetic-nodejs w/ packed version of this change of @google-cloud/synthetics-sdk-api.

![image](https://github.com/GoogleCloudPlatform/synthetics-sdk-nodejs/assets/66844903/59b9e6a6-0496-42ff-9688-3cdb9ec97878)


