### PR TITLE
chore: updates nodejs and ts samples to incorporate execution id

### DIFF
--- a/samples/generic-synthetic-nodejs/index.js
+++ b/samples/generic-synthetic-nodejs/index.js
@@ -20,13 +20,13 @@ const functions = require('@google-cloud/functions-framework');
 const axios = require('axios');
 const assert = require('node:assert');
 
-functions.http('SyntheticFunction', runSyntheticHandler(async ({logger}) => {
+functions.http('SyntheticFunction', runSyntheticHandler(async ({logger, executionId}) => {
   /*
    * This function executes the synthetic code for testing purposes.
    * If the code runs without errors, the synthetic test is considered successful.
    * If an error is thrown during execution, the synthetic test is considered failed.
    */
-  logger.info('Making an http request using synthetics');
+  logger.info('Making an http request using synthetics, with execution id: ' + executionId);
   const url = 'https://www.google.com/'; // URL to send the request to
   return await assert.doesNotReject(axios.get(url));
 }));

--- a/samples/generic-synthetic-nodejs/package.json
+++ b/samples/generic-synthetic-nodejs/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "dependencies": {
         "@google-cloud/functions-framework": "^3.1.2",
-        "@google-cloud/synthetics-sdk-api": "^0.4.0",
+        "@google-cloud/synthetics-sdk-api": "^0.4.1",
         "axios": "^1.5.0"
     },
     "license": "Apache-2.0",

--- a/samples/generic-synthetic-nodejs/package.json
+++ b/samples/generic-synthetic-nodejs/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "dependencies": {
         "@google-cloud/functions-framework": "^3.1.2",
-        "@google-cloud/synthetics-sdk-api": "^0.3.0",
+        "@google-cloud/synthetics-sdk-api": "^0.4.0",
         "axios": "^1.5.0"
     },
     "license": "Apache-2.0",

--- a/samples/generic-synthetic-typescript/package.json
+++ b/samples/generic-synthetic-typescript/package.json
@@ -14,7 +14,7 @@
     "author": "Google Inc.",
     "dependencies": {
         "@google-cloud/functions-framework": "^3.2.0",
-        "@google-cloud/synthetics-sdk-api": "^0.3.0",
+        "@google-cloud/synthetics-sdk-api": "^0.4.0",
         "axios": "^1.5.0",
         "winston": "^3.10.0"
     },

--- a/samples/generic-synthetic-typescript/package.json
+++ b/samples/generic-synthetic-typescript/package.json
@@ -14,7 +14,7 @@
     "author": "Google Inc.",
     "dependencies": {
         "@google-cloud/functions-framework": "^3.2.0",
-        "@google-cloud/synthetics-sdk-api": "^0.4.0",
+        "@google-cloud/synthetics-sdk-api": "^0.4.1",
         "axios": "^1.5.0",
         "winston": "^3.10.0"
     },

--- a/samples/generic-synthetic-typescript/src/index.ts
+++ b/samples/generic-synthetic-typescript/src/index.ts
@@ -21,13 +21,13 @@ import axios from 'axios';
 import assert from 'node:assert';
 import {Logger} from 'winston';
 
-ff.http('SyntheticFunction', runSyntheticHandler(async ({logger}: {logger: Logger}) => {
+ff.http('SyntheticFunction', runSyntheticHandler(async ({logger, executionId}: {logger: Logger, executionId: string|undefined}) => {
   /*
    * This function executes the synthetic code for testing purposes.
    * If the code runs without errors, the synthetic test is considered successful.
    * If an error is thrown during execution, the synthetic test is considered failed.
    */
-  logger.info('Making an http request using synthetics');
+  logger.info('Making an http request using synthetics, with execution id: ' + executionId);
   const url = 'https://www.google.com/'; // URL to send the request to
   return await assert.doesNotReject(axios.get(url));
 }));


### PR DESCRIPTION
Synthetics sdk v0.4.1 includes the ability to access execution id from within the user's code snippet. This change updates the samples to reflect the new feature.

Tested via cloud function deployment: 
- node js: 
![image](https://github.com/GoogleCloudPlatform/synthetics-sdk-nodejs/assets/113037085/4e9318d5-5fc2-452b-8846-980e547555f6)

- ts: 
![image](https://github.com/GoogleCloudPlatform/synthetics-sdk-nodejs/assets/113037085/740a5743-d48a-4c79-9a51-d5a215b3ebd5)
