### PR TITLE
fix: zero latency fix 

### DIFF
--- a/packages/synthetics-sdk-broken-links/src/link_utils.ts
+++ b/packages/synthetics-sdk-broken-links/src/link_utils.ts
@@ -303,5 +303,13 @@ export const getGenericSyntheticResult = (
   synthetic_generic_result_v1: getGenericError(genericErrorMessage),
   runtime_metadata: getRuntimeMetadata(),
   start_time: startTime,
-  end_time: new Date().toISOString(),
+  end_time: getEndTime(startTime),
 });
+
+const getEndTime = (startTime: string): string => {
+  const endDate = new Date();
+  if (endDate.toISOString() === startTime) {
+    endDate.setMilliseconds(endDate.getMilliseconds() + 1);
+  }
+  return endDate.toISOString();
+};

--- a/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
@@ -24,6 +24,7 @@ import { LinkOrder, StatusClass } from '../../src/broken_links';
 import {
   checkStatusPassing,
   createSyntheticResult,
+  getGenericSyntheticResult,
   LinkIntermediate,
   shuffleAndTruncate,
 } from '../../src/link_utils';
@@ -185,5 +186,18 @@ describe('GCM Synthetics Broken Links Utilies', async () => {
       // (this is to account for the origin_uri being included in link_limit)
       expect(truncatedLinks).to.have.lengthOf(link_limit - 1);
     });
+  });
+
+  it('getGenericSyntheticResult returns a minimum of 1 millisecond difference between start and end time', () => {
+    const genericResult = getGenericSyntheticResult(
+      new Date().toISOString(),
+      ''
+    );
+    const startTime = new Date(genericResult.start_time).getTime();
+    const endTime = new Date(genericResult.end_time).getTime();
+    const milliDifference = endTime - startTime;
+
+    expect(startTime).to.be.lessThan(endTime);
+    expect(milliDifference).to.be.greaterThan(0);
   });
 });


### PR DESCRIPTION
if SDK reports latency of 0 secs causes a bug in how we report metrics. This change makes sure that the minimum latency is 1 millisecond