### PR TITLE
feat: Add support through package to support users providing a `total_synthetic_timeout_millis` option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9694,8 +9694,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -10111,7 +10110,7 @@
     },
     "packages/synthetics-sdk-api": {
       "name": "@google-cloud/synthetics-sdk-api",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/opentelemetry-cloud-trace-exporter": "2.1.0",
@@ -10531,7 +10530,7 @@
       "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-cloud/synthetics-sdk-api": "^0.5.0",
+        "@google-cloud/synthetics-sdk-api": "^0.5.1",
         "puppeteer": "21.3.6"
       },
       "devDependencies": {
@@ -10553,20 +10552,277 @@
       }
     },
     "packages/synthetics-sdk-broken-links/node_modules/@google-cloud/synthetics-sdk-api": {
-      "version": "0.5.0",
-      "license": "Apache-2.0",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/synthetics-sdk-api/-/synthetics-sdk-api-0.5.1.tgz",
+      "integrity": "sha512-pzfCLlL2MvlxnGTqnSTKEE4icU+79Fuucm++Mnvifx9RMeq0gDwSRJYcx4nb1oKgfMS7TFoL+ejkIBn9uFDCOw==",
       "dependencies": {
-        "error-stack-parser": "^2.1.4",
-        "ts-proto": "^1.148.1"
+        "@google-cloud/opentelemetry-cloud-trace-exporter": "2.1.0",
+        "@opentelemetry/api": "1.6.0",
+        "@opentelemetry/auto-instrumentations-node": "0.39.2",
+        "@opentelemetry/instrumentation": "0.43.0",
+        "@opentelemetry/sdk-node": "0.43.0",
+        "@opentelemetry/sdk-trace-base": "1.17.0",
+        "@opentelemetry/sdk-trace-node": "1.17.0",
+        "error-stack-parser": "2.1.4",
+        "google-auth-library": "9.0.0",
+        "ts-proto": "1.148.1",
+        "winston": "3.10.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/api": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
+      "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/api-logs": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.43.0.tgz",
+      "integrity": "sha512-0CXMOYPXgAdLM2OzVkiUfAL6QQwWVhnMfUXCqLsITY42FZ9TxAhZIHkoc4mfVxvPuXsBnRYGR8UQZX86p87z4A==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/exporter-jaeger": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.17.0.tgz",
+      "integrity": "sha512-rWS5CQ+ns0NM3pmOAebaQdOmSnH6/7/P82EotaIq3zWrV5XRnKCRuILii457KnLqAI5zWjRTTEz2judEXNcCgg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.17.0",
+        "@opentelemetry/sdk-trace-base": "1.17.0",
+        "@opentelemetry/semantic-conventions": "1.17.0",
+        "jaeger-client": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.43.0.tgz",
+      "integrity": "sha512-h/oofzwyONMcAeBXD6+E6+foFQg9CPadBFcKAGoMIyVSK7iZgtK5DLEwAF4jz5MhfxWNmwZjHXFRc0GqCRx/tA==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.17.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.43.0",
+        "@opentelemetry/otlp-transformer": "0.43.0",
+        "@opentelemetry/resources": "1.17.0",
+        "@opentelemetry/sdk-trace-base": "1.17.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.43.0.tgz",
+      "integrity": "sha512-X6RGl4RTWC13EBrFstAbTh4vKqVqf6afpvFcud9qYhvl2A53OZ5RTAQP+9MrAMhthiKQaftNsEDdB2/0Sq+Xkw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.17.0",
+        "@opentelemetry/otlp-exporter-base": "0.43.0",
+        "@opentelemetry/otlp-transformer": "0.43.0",
+        "@opentelemetry/resources": "1.17.0",
+        "@opentelemetry/sdk-trace-base": "1.17.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.43.0.tgz",
+      "integrity": "sha512-a7gnB0MZ8/+BHH5Lt8UaKPv5yMAGvqj/7TceF4dvaFBOshjBZPrG628creAaKBIpuUwrpUtDRoTb1dbEMeO9tA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.17.0",
+        "@opentelemetry/otlp-exporter-base": "0.43.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.43.0",
+        "@opentelemetry/otlp-transformer": "0.43.0",
+        "@opentelemetry/resources": "1.17.0",
+        "@opentelemetry/sdk-trace-base": "1.17.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.17.0.tgz",
+      "integrity": "sha512-0eh/MOELhBByen+t2ZJVSOmtT1NlwSSqdAxu0+Id6ebTHVuslb/GLvJPPMU4Qz7zDHtSvFoR4/+AbOYtVmgQ1g==",
+      "dependencies": {
+        "@opentelemetry/core": "1.17.0",
+        "@opentelemetry/resources": "1.17.0",
+        "@opentelemetry/sdk-trace-base": "1.17.0",
+        "@opentelemetry/semantic-conventions": "1.17.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.43.0.tgz",
+      "integrity": "sha512-S1uHE+sxaepgp+t8lvIDuRgyjJWisAb733198kwQTUc9ZtYQ2V2gmyCtR1x21ePGVLoMiX/NWY7WA290hwkjJQ==",
+      "dependencies": {
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.4.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.43.0.tgz",
+      "integrity": "sha512-LXNtRFVuPRXB9q0qdvrLikQ3NtT9Jmv255Idryz3RJPhOh/Fa03sBASQoj3D55OH3xazmA90KFHfhJ/d8D8y4A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.17.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.43.0.tgz",
+      "integrity": "sha512-oOpqtDJo9BBa1+nD6ID1qZ55ZdTwEwSSn2idMobw8jmByJKaanVLdr9SJKsn5T9OBqo/c5QY2brMf0TNZkobJQ==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.17.0",
+        "@opentelemetry/otlp-exporter-base": "0.43.0",
+        "protobufjs": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/otlp-proto-exporter-base": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.43.0.tgz",
+      "integrity": "sha512-6s74egvK4MbN1ZYpaq5+k8wPe2s/OCUzz6aNwjLHGNAA/f4up6asTMlNE8F5PAmx2nQf2jvx+s90b6DjuEYElg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.17.0",
+        "@opentelemetry/otlp-exporter-base": "0.43.0",
+        "protobufjs": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.43.0.tgz",
+      "integrity": "sha512-KXYmgzWdVBOD5NvPmGW1nEMJjyQ8gK3N8r6pi4HvmEhTp0v4T13qDSax4q0HfsqmbPJR355oqQSJUnu1dHNutw==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.43.0",
+        "@opentelemetry/core": "1.17.0",
+        "@opentelemetry/resources": "1.17.0",
+        "@opentelemetry/sdk-logs": "0.43.0",
+        "@opentelemetry/sdk-metrics": "1.17.0",
+        "@opentelemetry/sdk-trace-base": "1.17.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.7.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.43.0.tgz",
+      "integrity": "sha512-JyJ2BBRKm37Mc4cSEhFmsMl5ASQn1dkGhEWzAAMSlhPtLRTv5PfvJwhR+Mboaic/eDLAlciwsgijq8IFlf6IgQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.17.0",
+        "@opentelemetry/resources": "1.17.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.7.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/@opentelemetry/sdk-node": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.43.0.tgz",
+      "integrity": "sha512-2C2OTZ7UgXahLAUBT4rpKHeQf/of349vZhHnljQNarvl3N5Oa8pu8dm6LLkiKHtLzX4LY26bpZuHiVjEzEwDoQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.43.0",
+        "@opentelemetry/core": "1.17.0",
+        "@opentelemetry/exporter-jaeger": "1.17.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.43.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.43.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.43.0",
+        "@opentelemetry/exporter-zipkin": "1.17.0",
+        "@opentelemetry/instrumentation": "0.43.0",
+        "@opentelemetry/resources": "1.17.0",
+        "@opentelemetry/sdk-logs": "0.43.0",
+        "@opentelemetry/sdk-metrics": "1.17.0",
+        "@opentelemetry/sdk-trace-base": "1.17.0",
+        "@opentelemetry/sdk-trace-node": "1.17.0",
+        "@opentelemetry/semantic-conventions": "1.17.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.7.0"
       }
     },
     "packages/synthetics-sdk-broken-links/node_modules/@types/node": {
       "version": "18.18.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",
       "integrity": "sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "packages/synthetics-sdk-broken-links/node_modules/diff": {
@@ -10576,6 +10832,101 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/gaxios": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.1.tgz",
+      "integrity": "sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/gcp-metadata": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/google-auth-library": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.0.0.tgz",
+      "integrity": "sha512-IQGjgQoVUAfOk6khqTVMLvWx26R+yPw9uLyb1MNyMQpdKiKt0Fd9sp4NWoINjyGHR8S3iw12hMTYK7O8J07c6Q==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.0.0",
+        "gcp-metadata": "^6.0.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/gtoken": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.0.1.tgz",
+      "integrity": "sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/https-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "packages/synthetics-sdk-broken-links/node_modules/protobufjs": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "packages/synthetics-sdk-broken-links/node_modules/sinon": {
@@ -11430,7 +11781,7 @@
       "version": "file:packages/synthetics-sdk-broken-links",
       "requires": {
         "@google-cloud/functions-framework": "^3.1.3",
-        "@google-cloud/synthetics-sdk-api": "^0.5.0",
+        "@google-cloud/synthetics-sdk-api": "^0.5.1",
         "@types/chai": "^4.3.4",
         "@types/express": "^4.17.17",
         "@types/node": "^18.15.10",
@@ -11446,19 +11797,194 @@
       },
       "dependencies": {
         "@google-cloud/synthetics-sdk-api": {
-          "version": "0.5.0",
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/@google-cloud/synthetics-sdk-api/-/synthetics-sdk-api-0.5.1.tgz",
+          "integrity": "sha512-pzfCLlL2MvlxnGTqnSTKEE4icU+79Fuucm++Mnvifx9RMeq0gDwSRJYcx4nb1oKgfMS7TFoL+ejkIBn9uFDCOw==",
           "requires": {
-            "error-stack-parser": "^2.1.4",
-            "ts-proto": "^1.148.1"
+            "@google-cloud/opentelemetry-cloud-trace-exporter": "2.1.0",
+            "@opentelemetry/api": "1.6.0",
+            "@opentelemetry/auto-instrumentations-node": "0.39.2",
+            "@opentelemetry/instrumentation": "0.43.0",
+            "@opentelemetry/sdk-node": "0.43.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0",
+            "@opentelemetry/sdk-trace-node": "1.17.0",
+            "error-stack-parser": "2.1.4",
+            "google-auth-library": "9.0.0",
+            "ts-proto": "1.148.1",
+            "winston": "3.10.0"
+          }
+        },
+        "@opentelemetry/api": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
+          "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g=="
+        },
+        "@opentelemetry/api-logs": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.43.0.tgz",
+          "integrity": "sha512-0CXMOYPXgAdLM2OzVkiUfAL6QQwWVhnMfUXCqLsITY42FZ9TxAhZIHkoc4mfVxvPuXsBnRYGR8UQZX86p87z4A==",
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        },
+        "@opentelemetry/exporter-jaeger": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.17.0.tgz",
+          "integrity": "sha512-rWS5CQ+ns0NM3pmOAebaQdOmSnH6/7/P82EotaIq3zWrV5XRnKCRuILii457KnLqAI5zWjRTTEz2judEXNcCgg==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0",
+            "@opentelemetry/semantic-conventions": "1.17.0",
+            "jaeger-client": "^3.15.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-grpc": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.43.0.tgz",
+          "integrity": "sha512-h/oofzwyONMcAeBXD6+E6+foFQg9CPadBFcKAGoMIyVSK7iZgtK5DLEwAF4jz5MhfxWNmwZjHXFRc0GqCRx/tA==",
+          "requires": {
+            "@grpc/grpc-js": "^1.7.1",
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/otlp-grpc-exporter-base": "0.43.0",
+            "@opentelemetry/otlp-transformer": "0.43.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.43.0.tgz",
+          "integrity": "sha512-X6RGl4RTWC13EBrFstAbTh4vKqVqf6afpvFcud9qYhvl2A53OZ5RTAQP+9MrAMhthiKQaftNsEDdB2/0Sq+Xkw==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/otlp-exporter-base": "0.43.0",
+            "@opentelemetry/otlp-transformer": "0.43.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.43.0.tgz",
+          "integrity": "sha512-a7gnB0MZ8/+BHH5Lt8UaKPv5yMAGvqj/7TceF4dvaFBOshjBZPrG628creAaKBIpuUwrpUtDRoTb1dbEMeO9tA==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/otlp-exporter-base": "0.43.0",
+            "@opentelemetry/otlp-proto-exporter-base": "0.43.0",
+            "@opentelemetry/otlp-transformer": "0.43.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0"
+          }
+        },
+        "@opentelemetry/exporter-zipkin": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.17.0.tgz",
+          "integrity": "sha512-0eh/MOELhBByen+t2ZJVSOmtT1NlwSSqdAxu0+Id6ebTHVuslb/GLvJPPMU4Qz7zDHtSvFoR4/+AbOYtVmgQ1g==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0",
+            "@opentelemetry/semantic-conventions": "1.17.0"
+          }
+        },
+        "@opentelemetry/instrumentation": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.43.0.tgz",
+          "integrity": "sha512-S1uHE+sxaepgp+t8lvIDuRgyjJWisAb733198kwQTUc9ZtYQ2V2gmyCtR1x21ePGVLoMiX/NWY7WA290hwkjJQ==",
+          "requires": {
+            "@types/shimmer": "^1.0.2",
+            "import-in-the-middle": "1.4.2",
+            "require-in-the-middle": "^7.1.1",
+            "semver": "^7.5.2",
+            "shimmer": "^1.2.1"
+          }
+        },
+        "@opentelemetry/otlp-exporter-base": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.43.0.tgz",
+          "integrity": "sha512-LXNtRFVuPRXB9q0qdvrLikQ3NtT9Jmv255Idryz3RJPhOh/Fa03sBASQoj3D55OH3xazmA90KFHfhJ/d8D8y4A==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0"
+          }
+        },
+        "@opentelemetry/otlp-grpc-exporter-base": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.43.0.tgz",
+          "integrity": "sha512-oOpqtDJo9BBa1+nD6ID1qZ55ZdTwEwSSn2idMobw8jmByJKaanVLdr9SJKsn5T9OBqo/c5QY2brMf0TNZkobJQ==",
+          "requires": {
+            "@grpc/grpc-js": "^1.7.1",
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/otlp-exporter-base": "0.43.0",
+            "protobufjs": "^7.2.3"
+          }
+        },
+        "@opentelemetry/otlp-proto-exporter-base": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.43.0.tgz",
+          "integrity": "sha512-6s74egvK4MbN1ZYpaq5+k8wPe2s/OCUzz6aNwjLHGNAA/f4up6asTMlNE8F5PAmx2nQf2jvx+s90b6DjuEYElg==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/otlp-exporter-base": "0.43.0",
+            "protobufjs": "^7.2.3"
+          }
+        },
+        "@opentelemetry/otlp-transformer": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.43.0.tgz",
+          "integrity": "sha512-KXYmgzWdVBOD5NvPmGW1nEMJjyQ8gK3N8r6pi4HvmEhTp0v4T13qDSax4q0HfsqmbPJR355oqQSJUnu1dHNutw==",
+          "requires": {
+            "@opentelemetry/api-logs": "0.43.0",
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-logs": "0.43.0",
+            "@opentelemetry/sdk-metrics": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0"
+          }
+        },
+        "@opentelemetry/sdk-logs": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.43.0.tgz",
+          "integrity": "sha512-JyJ2BBRKm37Mc4cSEhFmsMl5ASQn1dkGhEWzAAMSlhPtLRTv5PfvJwhR+Mboaic/eDLAlciwsgijq8IFlf6IgQ==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/resources": "1.17.0"
+          }
+        },
+        "@opentelemetry/sdk-node": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.43.0.tgz",
+          "integrity": "sha512-2C2OTZ7UgXahLAUBT4rpKHeQf/of349vZhHnljQNarvl3N5Oa8pu8dm6LLkiKHtLzX4LY26bpZuHiVjEzEwDoQ==",
+          "requires": {
+            "@opentelemetry/api-logs": "0.43.0",
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/exporter-jaeger": "1.17.0",
+            "@opentelemetry/exporter-trace-otlp-grpc": "0.43.0",
+            "@opentelemetry/exporter-trace-otlp-http": "0.43.0",
+            "@opentelemetry/exporter-trace-otlp-proto": "0.43.0",
+            "@opentelemetry/exporter-zipkin": "1.17.0",
+            "@opentelemetry/instrumentation": "0.43.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-logs": "0.43.0",
+            "@opentelemetry/sdk-metrics": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0",
+            "@opentelemetry/sdk-trace-node": "1.17.0",
+            "@opentelemetry/semantic-conventions": "1.17.0"
           }
         },
         "@types/node": {
           "version": "18.18.8",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",
           "integrity": "sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==",
-          "dev": true,
           "requires": {
             "undici-types": "~5.26.4"
+          }
+        },
+        "agent-base": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "requires": {
+            "debug": "^4.3.4"
           }
         },
         "diff": {
@@ -11466,6 +11992,82 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
           "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
           "dev": true
+        },
+        "gaxios": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.1.tgz",
+          "integrity": "sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==",
+          "requires": {
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^7.0.1",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.9"
+          }
+        },
+        "gcp-metadata": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+          "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+          "requires": {
+            "gaxios": "^6.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.0.0.tgz",
+          "integrity": "sha512-IQGjgQoVUAfOk6khqTVMLvWx26R+yPw9uLyb1MNyMQpdKiKt0Fd9sp4NWoINjyGHR8S3iw12hMTYK7O8J07c6Q==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "gaxios": "^6.0.0",
+            "gcp-metadata": "^6.0.0",
+            "gtoken": "^7.0.0",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "gtoken": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.0.1.tgz",
+          "integrity": "sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==",
+          "requires": {
+            "gaxios": "^6.0.0",
+            "jws": "^4.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+          "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+          }
+        },
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        },
+        "protobufjs": {
+          "version": "7.2.6",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+          "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          }
         },
         "sinon": {
           "version": "15.2.0",
@@ -17795,7 +18397,7 @@
       "version": "file:packages/synthetics-sdk-broken-links",
       "requires": {
         "@google-cloud/functions-framework": "^3.1.3",
-        "@google-cloud/synthetics-sdk-api": "^0.5.0",
+        "@google-cloud/synthetics-sdk-api": "^0.5.1",
         "@types/chai": "^4.3.4",
         "@types/express": "^4.17.17",
         "@types/node": "^18.15.10",
@@ -17811,19 +18413,194 @@
       },
       "dependencies": {
         "@google-cloud/synthetics-sdk-api": {
-          "version": "0.5.0",
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/@google-cloud/synthetics-sdk-api/-/synthetics-sdk-api-0.5.1.tgz",
+          "integrity": "sha512-pzfCLlL2MvlxnGTqnSTKEE4icU+79Fuucm++Mnvifx9RMeq0gDwSRJYcx4nb1oKgfMS7TFoL+ejkIBn9uFDCOw==",
           "requires": {
-            "error-stack-parser": "^2.1.4",
-            "ts-proto": "^1.148.1"
+            "@google-cloud/opentelemetry-cloud-trace-exporter": "2.1.0",
+            "@opentelemetry/api": "1.6.0",
+            "@opentelemetry/auto-instrumentations-node": "0.39.2",
+            "@opentelemetry/instrumentation": "0.43.0",
+            "@opentelemetry/sdk-node": "0.43.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0",
+            "@opentelemetry/sdk-trace-node": "1.17.0",
+            "error-stack-parser": "2.1.4",
+            "google-auth-library": "9.0.0",
+            "ts-proto": "1.148.1",
+            "winston": "3.10.0"
+          }
+        },
+        "@opentelemetry/api": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
+          "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g=="
+        },
+        "@opentelemetry/api-logs": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.43.0.tgz",
+          "integrity": "sha512-0CXMOYPXgAdLM2OzVkiUfAL6QQwWVhnMfUXCqLsITY42FZ9TxAhZIHkoc4mfVxvPuXsBnRYGR8UQZX86p87z4A==",
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        },
+        "@opentelemetry/exporter-jaeger": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.17.0.tgz",
+          "integrity": "sha512-rWS5CQ+ns0NM3pmOAebaQdOmSnH6/7/P82EotaIq3zWrV5XRnKCRuILii457KnLqAI5zWjRTTEz2judEXNcCgg==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0",
+            "@opentelemetry/semantic-conventions": "1.17.0",
+            "jaeger-client": "^3.15.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-grpc": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.43.0.tgz",
+          "integrity": "sha512-h/oofzwyONMcAeBXD6+E6+foFQg9CPadBFcKAGoMIyVSK7iZgtK5DLEwAF4jz5MhfxWNmwZjHXFRc0GqCRx/tA==",
+          "requires": {
+            "@grpc/grpc-js": "^1.7.1",
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/otlp-grpc-exporter-base": "0.43.0",
+            "@opentelemetry/otlp-transformer": "0.43.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.43.0.tgz",
+          "integrity": "sha512-X6RGl4RTWC13EBrFstAbTh4vKqVqf6afpvFcud9qYhvl2A53OZ5RTAQP+9MrAMhthiKQaftNsEDdB2/0Sq+Xkw==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/otlp-exporter-base": "0.43.0",
+            "@opentelemetry/otlp-transformer": "0.43.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.43.0.tgz",
+          "integrity": "sha512-a7gnB0MZ8/+BHH5Lt8UaKPv5yMAGvqj/7TceF4dvaFBOshjBZPrG628creAaKBIpuUwrpUtDRoTb1dbEMeO9tA==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/otlp-exporter-base": "0.43.0",
+            "@opentelemetry/otlp-proto-exporter-base": "0.43.0",
+            "@opentelemetry/otlp-transformer": "0.43.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0"
+          }
+        },
+        "@opentelemetry/exporter-zipkin": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.17.0.tgz",
+          "integrity": "sha512-0eh/MOELhBByen+t2ZJVSOmtT1NlwSSqdAxu0+Id6ebTHVuslb/GLvJPPMU4Qz7zDHtSvFoR4/+AbOYtVmgQ1g==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0",
+            "@opentelemetry/semantic-conventions": "1.17.0"
+          }
+        },
+        "@opentelemetry/instrumentation": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.43.0.tgz",
+          "integrity": "sha512-S1uHE+sxaepgp+t8lvIDuRgyjJWisAb733198kwQTUc9ZtYQ2V2gmyCtR1x21ePGVLoMiX/NWY7WA290hwkjJQ==",
+          "requires": {
+            "@types/shimmer": "^1.0.2",
+            "import-in-the-middle": "1.4.2",
+            "require-in-the-middle": "^7.1.1",
+            "semver": "^7.5.2",
+            "shimmer": "^1.2.1"
+          }
+        },
+        "@opentelemetry/otlp-exporter-base": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.43.0.tgz",
+          "integrity": "sha512-LXNtRFVuPRXB9q0qdvrLikQ3NtT9Jmv255Idryz3RJPhOh/Fa03sBASQoj3D55OH3xazmA90KFHfhJ/d8D8y4A==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0"
+          }
+        },
+        "@opentelemetry/otlp-grpc-exporter-base": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.43.0.tgz",
+          "integrity": "sha512-oOpqtDJo9BBa1+nD6ID1qZ55ZdTwEwSSn2idMobw8jmByJKaanVLdr9SJKsn5T9OBqo/c5QY2brMf0TNZkobJQ==",
+          "requires": {
+            "@grpc/grpc-js": "^1.7.1",
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/otlp-exporter-base": "0.43.0",
+            "protobufjs": "^7.2.3"
+          }
+        },
+        "@opentelemetry/otlp-proto-exporter-base": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.43.0.tgz",
+          "integrity": "sha512-6s74egvK4MbN1ZYpaq5+k8wPe2s/OCUzz6aNwjLHGNAA/f4up6asTMlNE8F5PAmx2nQf2jvx+s90b6DjuEYElg==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/otlp-exporter-base": "0.43.0",
+            "protobufjs": "^7.2.3"
+          }
+        },
+        "@opentelemetry/otlp-transformer": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.43.0.tgz",
+          "integrity": "sha512-KXYmgzWdVBOD5NvPmGW1nEMJjyQ8gK3N8r6pi4HvmEhTp0v4T13qDSax4q0HfsqmbPJR355oqQSJUnu1dHNutw==",
+          "requires": {
+            "@opentelemetry/api-logs": "0.43.0",
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-logs": "0.43.0",
+            "@opentelemetry/sdk-metrics": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0"
+          }
+        },
+        "@opentelemetry/sdk-logs": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.43.0.tgz",
+          "integrity": "sha512-JyJ2BBRKm37Mc4cSEhFmsMl5ASQn1dkGhEWzAAMSlhPtLRTv5PfvJwhR+Mboaic/eDLAlciwsgijq8IFlf6IgQ==",
+          "requires": {
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/resources": "1.17.0"
+          }
+        },
+        "@opentelemetry/sdk-node": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.43.0.tgz",
+          "integrity": "sha512-2C2OTZ7UgXahLAUBT4rpKHeQf/of349vZhHnljQNarvl3N5Oa8pu8dm6LLkiKHtLzX4LY26bpZuHiVjEzEwDoQ==",
+          "requires": {
+            "@opentelemetry/api-logs": "0.43.0",
+            "@opentelemetry/core": "1.17.0",
+            "@opentelemetry/exporter-jaeger": "1.17.0",
+            "@opentelemetry/exporter-trace-otlp-grpc": "0.43.0",
+            "@opentelemetry/exporter-trace-otlp-http": "0.43.0",
+            "@opentelemetry/exporter-trace-otlp-proto": "0.43.0",
+            "@opentelemetry/exporter-zipkin": "1.17.0",
+            "@opentelemetry/instrumentation": "0.43.0",
+            "@opentelemetry/resources": "1.17.0",
+            "@opentelemetry/sdk-logs": "0.43.0",
+            "@opentelemetry/sdk-metrics": "1.17.0",
+            "@opentelemetry/sdk-trace-base": "1.17.0",
+            "@opentelemetry/sdk-trace-node": "1.17.0",
+            "@opentelemetry/semantic-conventions": "1.17.0"
           }
         },
         "@types/node": {
           "version": "18.18.8",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",
           "integrity": "sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==",
-          "dev": true,
           "requires": {
             "undici-types": "~5.26.4"
+          }
+        },
+        "agent-base": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "requires": {
+            "debug": "^4.3.4"
           }
         },
         "diff": {
@@ -17831,6 +18608,82 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
           "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
           "dev": true
+        },
+        "gaxios": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.1.tgz",
+          "integrity": "sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==",
+          "requires": {
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^7.0.1",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.9"
+          }
+        },
+        "gcp-metadata": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+          "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+          "requires": {
+            "gaxios": "^6.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.0.0.tgz",
+          "integrity": "sha512-IQGjgQoVUAfOk6khqTVMLvWx26R+yPw9uLyb1MNyMQpdKiKt0Fd9sp4NWoINjyGHR8S3iw12hMTYK7O8J07c6Q==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "gaxios": "^6.0.0",
+            "gcp-metadata": "^6.0.0",
+            "gtoken": "^7.0.0",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "gtoken": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.0.1.tgz",
+          "integrity": "sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==",
+          "requires": {
+            "gaxios": "^6.0.0",
+            "jws": "^4.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+          "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+          }
+        },
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        },
+        "protobufjs": {
+          "version": "7.2.6",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+          "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          }
         },
         "sinon": {
           "version": "15.2.0",
@@ -18229,8 +19082,7 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "universalify": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10127,14 +10127,14 @@
         "winston": "3.10.0"
       },
       "devDependencies": {
-        "@google-cloud/functions-framework": "3.1.1",
+        "@google-cloud/functions-framework": "^3.1.1",
         "@google-cloud/synthetics-sdk-api": "file:./",
         "@types/chai": "^4.3.4",
         "@types/express": "^4.17.17",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.15.10",
         "@types/sinon": "^10.0.16",
-        "@types/supertest": "2.0.12",
+        "@types/supertest": "^2.0.12",
         "chai": "^4.3.7",
         "express": "^4.18.2",
         "node-mocks-http": "^1.13.0",
@@ -10527,9 +10527,8 @@
       }
     },
     "packages/synthetics-sdk-broken-links": {
-      "version": "0.1.0",
-      "dev": true,
-      "hasInstallScript": true,
+      "name": "@google-cloud/synthetics-sdk-broken-links",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/synthetics-sdk-api": "^0.5.0",
@@ -11123,7 +11122,7 @@
     "@google-cloud/synthetics-sdk-api": {
       "version": "file:packages/synthetics-sdk-api",
       "requires": {
-        "@google-cloud/functions-framework": "3.1.1",
+        "@google-cloud/functions-framework": "^3.1.1",
         "@google-cloud/opentelemetry-cloud-trace-exporter": "2.1.0",
         "@google-cloud/synthetics-sdk-api": "file:",
         "@opentelemetry/api": "1.6.0",
@@ -11137,7 +11136,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.15.10",
         "@types/sinon": "^10.0.16",
-        "@types/supertest": "2.0.12",
+        "@types/supertest": "^2.0.12",
         "chai": "^4.3.7",
         "error-stack-parser": "2.1.4",
         "express": "^4.18.2",
@@ -11446,6 +11445,13 @@
         "synthetics-sdk-broken-links": "file:"
       },
       "dependencies": {
+        "@google-cloud/synthetics-sdk-api": {
+          "version": "0.5.0",
+          "requires": {
+            "error-stack-parser": "^2.1.4",
+            "ts-proto": "^1.148.1"
+          }
+        },
         "@types/node": {
           "version": "18.18.8",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",
@@ -17804,6 +17810,13 @@
         "synthetics-sdk-broken-links": "file:"
       },
       "dependencies": {
+        "@google-cloud/synthetics-sdk-api": {
+          "version": "0.5.0",
+          "requires": {
+            "error-stack-parser": "^2.1.4",
+            "ts-proto": "^1.148.1"
+          }
+        },
         "@types/node": {
           "version": "18.18.8",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",

--- a/packages/synthetics-sdk-api/src/generated/proto/synthetic_response.ts
+++ b/packages/synthetics-sdk-api/src/generated/proto/synthetic_response.ts
@@ -1,17 +1,3 @@
-// Copyright 2023 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 /* eslint-disable */
 import Long from "long";
 import _m0 from "protobufjs/minimal";

--- a/packages/synthetics-sdk-api/src/generated/proto/synthetic_response.ts
+++ b/packages/synthetics-sdk-api/src/generated/proto/synthetic_response.ts
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /* eslint-disable */
 import Long from "long";
 import _m0 from "protobufjs/minimal";

--- a/packages/synthetics-sdk-broken-links/package.json
+++ b/packages/synthetics-sdk-broken-links/package.json
@@ -40,7 +40,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@google-cloud/synthetics-sdk-api": "^0.5.0",
+    "@google-cloud/synthetics-sdk-api": "^0.5.1",
     "puppeteer": "21.3.6"
   }
 }

--- a/packages/synthetics-sdk-broken-links/src/options_func.ts
+++ b/packages/synthetics-sdk-broken-links/src/options_func.ts
@@ -32,7 +32,9 @@ import {
  * @returns The sanitized input options if validation passes.
  * @throws {Error} If any of the input options fail validation.
  */
-export function validateInputOptions(inputOptions: BrokenLinkCheckerOptions) {
+export function validateInputOptions(
+  inputOptions: BrokenLinkCheckerOptions
+): BrokenLinkCheckerOptions {
   if (!inputOptions.origin_uri) {
     throw new Error('Missing origin_uri in options');
   } else if (
@@ -116,6 +118,18 @@ export function validateInputOptions(inputOptions: BrokenLinkCheckerOptions) {
     throw new Error('Invalid wait_for_selector value, must be a string');
   }
 
+  // Check total_synthetic_timeout_millis
+  if (
+    inputOptions.total_synthetic_timeout_millis !== undefined &&
+    (typeof inputOptions.total_synthetic_timeout_millis !== 'number' ||
+      inputOptions.total_synthetic_timeout_millis < 30000 ||
+      inputOptions.total_synthetic_timeout_millis > 60000)
+  ) {
+    throw new Error(
+      'Invalid total_synthetic_timeout_millis value, must be a number between 30000 and 60000 inclusive'
+    );
+  }
+
   // per_link_options
   for (const [key, value] of Object.entries(
     inputOptions.per_link_options || {}
@@ -165,6 +179,7 @@ export function validateInputOptions(inputOptions: BrokenLinkCheckerOptions) {
     max_retries: inputOptions.max_retries,
     wait_for_selector: inputOptions.wait_for_selector,
     per_link_options: inputOptions.per_link_options,
+    total_synthetic_timeout_millis: inputOptions.total_synthetic_timeout_millis,
   };
 }
 
@@ -187,6 +202,7 @@ export function setDefaultOptions(
     max_retries: 0,
     wait_for_selector: '',
     per_link_options: {},
+    total_synthetic_timeout_millis: 60000,
   };
 
   const outputOptions: BrokenLinksResultV1_BrokenLinkCheckerOptions =

--- a/packages/synthetics-sdk-broken-links/test/integration/integration.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/integration/integration.spec.ts
@@ -136,6 +136,7 @@ describe('CloudFunctionV2 Running Broken Link Synthetics', async () => {
       max_retries: 0,
       wait_for_selector: '',
       per_link_options: {},
+      total_synthetic_timeout_millis: 60000,
     });
 
     expect(origin_link)
@@ -242,6 +243,7 @@ describe('CloudFunctionV2 Running Broken Link Synthetics', async () => {
       max_retries: 0,
       wait_for_selector: '',
       per_link_options: {},
+      total_synthetic_timeout_millis: 60000,
     });
 
     expect(origin_link)
@@ -364,6 +366,7 @@ describe('CloudFunctionV2 Running Broken Link Synthetics', async () => {
       max_retries: 0,
       wait_for_selector: '',
       per_link_options: {},
+      total_synthetic_timeout_millis: 60000,
     });
 
     expect(origin_link)

--- a/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/broken_links.spec.ts
@@ -84,9 +84,10 @@ describe('runBrokenLinks', async () => {
       query_selector_all: 'a[src], img[href]',
       get_attributes: ['href', 'src'],
       wait_for_selector: 'none existent',
-      link_timeout_millis: 5000,
+      link_timeout_millis: 35000,
+      total_synthetic_timeout_millis: 31000,
     };
-    const result = await runBrokenLinks(inputOptions, 3000);
+    const result = await runBrokenLinks(inputOptions);
     const broken_links_result = result.synthetic_broken_links_result_v1;
 
     const expectedOriginLinkResult: BrokenLinksResultV1_SyntheticLinkResult = {
@@ -99,7 +100,7 @@ describe('runBrokenLinks', async () => {
       status_code: 200,
       error_type: 'TimeoutError',
       error_message:
-        "Global Timeout of 60 secs hit while waiting for selector 'none existent'",
+        "Total Synthetic Timeout of 31000 milliseconds hit while waiting for selector 'none existent'",
       link_start_time: 'NA',
       link_end_time: 'NA',
       is_origin: true,
@@ -109,7 +110,7 @@ describe('runBrokenLinks', async () => {
       .excluding(['link_start_time', 'link_end_time'])
       .to.deep.equal(expectedOriginLinkResult);
     expect(broken_links_result?.followed_link_results.length).to.equal(0);
-  }).timeout(5000);
+  }).timeout(40000);
 
   it('successful execution with 1 failing link', async () => {
     const origin_uri = `file:${path.join(
@@ -136,6 +137,7 @@ describe('runBrokenLinks', async () => {
       max_retries: 0,
       wait_for_selector: '',
       per_link_options: {},
+      total_synthetic_timeout_millis: 60000,
     };
 
     const expectedOriginLinkResult: BrokenLinksResultV1_SyntheticLinkResult = {

--- a/packages/synthetics-sdk-broken-links/test/unit/options_func.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/options_func.spec.ts
@@ -267,6 +267,30 @@ describe('GCM Synthetics Broken Links  options_func suite testing', () => {
         validateInputOptions(options);
       }).not.to.throw();
     });
+    it('throws error if total_synthetic_timeout_millis is less than 30000', () => {
+      const options = {
+        origin_uri: 'http://example.com',
+        total_synthetic_timeout_millis: 29000,
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid total_synthetic_timeout_millis value, must be a number between 30000 and 60000 inclusive'
+      );
+    });
+    it('throws error if total_synthetic_timeout_millis is more than 60000', () => {
+      const options = {
+        origin_uri: 'http://example.com',
+        total_synthetic_timeout_millis: 61000,
+      } as BrokenLinkCheckerOptions;
+      expect(() => {
+        validateInputOptions(options);
+      }).to.throw(
+        Error,
+        'Invalid total_synthetic_timeout_millis value, must be a number between 30000 and 60000 inclusive'
+      );
+    });
     it('throws error if per_link_options contains an invalid uri', () => {
       const options = {
         origin_uri: 'http://example.com',
@@ -382,6 +406,7 @@ describe('GCM Synthetics Broken Links  options_func suite testing', () => {
         max_retries: undefined,
         wait_for_selector: undefined,
         per_link_options: undefined,
+        total_synthetic_timeout_millis: undefined
       } as BrokenLinkCheckerOptions;
 
       expect(() => {


### PR DESCRIPTION
Allows users to specify how long the synthetic is going to run. We then remove 7 seconds from this time and return all the links we've been able to check in that time.

Support for this already existed but it was hard coded to 50 seconds. This change is exposing this capability to the user.