### PR TITLE
Refactor Integration Tests & Organize Imports

### DIFF
--- a/packages/synthetics-sdk-broken-links/src/broken_links.ts
+++ b/packages/synthetics-sdk-broken-links/src/broken_links.ts
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import puppeteer, { Browser, Page } from 'puppeteer';
-import { Bucket } from '@google-cloud/storage';
+// Internal Project Files
 import {
   BaseError,
   BrokenLinksResultV1_BrokenLinkCheckerOptions,
   BrokenLinksResultV1_SyntheticLinkResult,
-  instantiateMetadata,
   getRuntimeMetadata,
+  instantiateMetadata,
   SyntheticResult,
 } from '@google-cloud/synthetics-sdk-api';
 import {
@@ -34,14 +33,18 @@ import {
   checkLinks,
   closeBrowser,
   closePagePool,
-  retrieveLinksFromPage,
   openNewPage,
+  retrieveLinksFromPage,
 } from './navigation_func';
 import { processOptions } from './options_func';
 import {
   createStorageClientIfStorageSelected,
   getOrCreateStorageBucket,
 } from './storage_func';
+
+// External Dependencies
+import { Bucket } from '@google-cloud/storage';
+import puppeteer, { Browser, Page } from 'puppeteer';
 
 export interface BrokenLinkCheckerOptions {
   origin_uri: string;

--- a/packages/synthetics-sdk-broken-links/src/handlers.ts
+++ b/packages/synthetics-sdk-broken-links/src/handlers.ts
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { runBrokenLinks, BrokenLinkCheckerOptions } from './broken_links';
+// Standard Libraries
 import { Request, Response } from 'express';
+
+// Internal Project Files
+import { runBrokenLinks, BrokenLinkCheckerOptions } from './broken_links';
 
 /**
  * Middleware for easy invocation of SyntheticSDK broken links, and may be used to

--- a/packages/synthetics-sdk-broken-links/src/index.ts
+++ b/packages/synthetics-sdk-broken-links/src/index.ts
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 export {
-  runBrokenLinks,
   BrokenLinkCheckerOptions,
-  PerLinkOption,
-  StatusClass,
   LinkOrder,
+  PerLinkOption,
+  runBrokenLinks,
+  StatusClass,
 } from './broken_links';
 export * from './handlers';
 export * from '@google-cloud/synthetics-sdk-api';

--- a/packages/synthetics-sdk-broken-links/src/link_utils.ts
+++ b/packages/synthetics-sdk-broken-links/src/link_utils.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { HTTPResponse } from 'puppeteer';
+// Internal Project Files
 import {
   BaseError,
   BrokenLinksResultV1,
@@ -25,6 +25,9 @@ import {
   ResponseStatusCode_StatusClass,
   SyntheticResult,
 } from '@google-cloud/synthetics-sdk-api';
+
+// External Dependencies
+import { HTTPResponse } from 'puppeteer';
 
 /**
  * Represents an intermediate link with its properties.

--- a/packages/synthetics-sdk-broken-links/src/navigation_func.ts
+++ b/packages/synthetics-sdk-broken-links/src/navigation_func.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Browser, HTTPResponse, Page } from 'puppeteer';
+// Internal Project Files
 import {
+  BaseError,
   BrokenLinksResultV1_BrokenLinkCheckerOptions,
   BrokenLinksResultV1_SyntheticLinkResult,
-  BaseError,
   ResponseStatusCode,
   ResponseStatusCode_StatusClass,
 } from '@google-cloud/synthetics-sdk-api';
@@ -28,6 +28,9 @@ import {
   NavigateResponse,
   getTimeLimitPromise,
 } from './link_utils';
+
+// External Dependencies
+import { Browser, HTTPResponse, Page } from 'puppeteer';
 
 /**
  * Retrieves all links on the page using Puppeteer, handling relative and

--- a/packages/synthetics-sdk-broken-links/src/options_func.ts
+++ b/packages/synthetics-sdk-broken-links/src/options_func.ts
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Internal Project Files
+import {
+  BrokenLinkCheckerOptions,
+  CaptureCondition,
+  LinkOrder,
+  StatusClass,
+} from './broken_links';
 import {
   BrokenLinksResultV1_BrokenLinkCheckerOptions,
   BrokenLinksResultV1_BrokenLinkCheckerOptions_LinkOrder,
@@ -21,12 +28,6 @@ import {
   ResponseStatusCode,
   ResponseStatusCode_StatusClass,
 } from '@google-cloud/synthetics-sdk-api';
-import {
-  BrokenLinkCheckerOptions,
-  LinkOrder,
-  StatusClass,
-  CaptureCondition,
-} from './broken_links';
 
 /**
  * Validates input options and sets defaults in `options`.

--- a/packages/synthetics-sdk-broken-links/src/storage_func.ts
+++ b/packages/synthetics-sdk-broken-links/src/storage_func.ts
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Standard Libraries
 import * as path from 'path';
-import { Storage, Bucket } from '@google-cloud/storage';
+
+// Internal Project Files
 import {
   BaseError,
   BrokenLinksResultV1_BrokenLinkCheckerOptions,
   BrokenLinksResultV1_BrokenLinkCheckerOptions_ScreenshotOptions_CaptureCondition as ApiCaptureCondition,
-  resolveProjectId,
-  getExecutionRegion,
   BrokenLinksResultV1_SyntheticLinkResult_ScreenshotOutput as ApiScreenshotOutput,
+  getExecutionRegion,
+  resolveProjectId,
 } from '@google-cloud/synthetics-sdk-api';
+
+// External Dependencies
+import { Storage, Bucket } from '@google-cloud/storage';
 
 export interface StorageParameters {
   storageClient: Storage | null;

--- a/packages/synthetics-sdk-broken-links/test/example_html_files/integration_server.js
+++ b/packages/synthetics-sdk-broken-links/test/example_html_files/integration_server.js
@@ -12,22 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const functions = require('@google-cloud/functions-framework');
-const SyntheticsSdkBrokenLinks = require('synthetics-sdk-broken-links');
+// Standard Libraries
 const path = require('path');
+
+// Internal Project Files
+const SyntheticsSdkBrokenLinks = require('synthetics-sdk-broken-links');
+
+// External Dependencies
+const functions = require('@google-cloud/functions-framework');
 
 /*
  * This is the server template that is required to run a synthetic monitor in
  * Google Cloud Functions.
  */
-
-// Handles error when trying to visit page that does not exist
-functions.http('BrokenLinksPageDoesNotExist', SyntheticsSdkBrokenLinks.runBrokenLinksHandler({
-  origin_uri: `file:${path.join(
-    __dirname,
-    '../example_html_files/file_doesnt_exist.html'
-  )}`
-}));
 
 // Visits and checks empty page with no links
 functions.http('BrokenLinksEmptyPageOk', SyntheticsSdkBrokenLinks.runBrokenLinksHandler({
@@ -35,33 +32,4 @@ functions.http('BrokenLinksEmptyPageOk', SyntheticsSdkBrokenLinks.runBrokenLinks
     __dirname,
     '../example_html_files/200.html'
   )}`
-}));
-
-// Exits early when options cannot be parsed
-functions.http('BrokenLinksInvalidOptionsNotOk', SyntheticsSdkBrokenLinks.runBrokenLinksHandler({
-  origin_uri: `file:${path.join(
-    __dirname,
-    '../example_html_files/retrieve_links_test.html'
-  )}`,
-  link_order: 'incorrect'
-}));
-
-// Completes full failing execution
-functions.http('BrokenLinksFailingOk', SyntheticsSdkBrokenLinks.runBrokenLinksHandler({
-  origin_uri: `file:${path.join(
-    __dirname,
-    '../example_html_files/retrieve_links_test.html'
-  )}`,
-  query_selector_all: 'a[src], img[href]',
-  get_attributes: ['href', 'src']
-}));
-
-// Completes full passing execution
-functions.http('BrokenLinksPassingOk', SyntheticsSdkBrokenLinks.runBrokenLinksHandler({
-  origin_uri: `file:${path.join(
-    __dirname,
-    '../example_html_files/retrieve_links_test.html'
-  )}`,
-  query_selector_all: 'a[src]',
-  get_attributes: ['src']
 }));

--- a/packages/synthetics-sdk-broken-links/test/integration/integration.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/integration/integration.spec.ts
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Standard Libraries
+import { expect } from 'chai';
+import supertest from 'supertest';
+const path = require('path');
+
+// Internal Project Files
 import {
   BaseError,
   BrokenLinksResultV1_BrokenLinkCheckerOptions_LinkOrder,
@@ -22,88 +28,25 @@ import {
   SyntheticResult,
 } from '@google-cloud/synthetics-sdk-api';
 
-import { expect } from 'chai';
-import supertest from 'supertest';
-const path = require('path');
-
+// External Dependencies
 require('../../test/example_html_files/integration_server.js');
 const { getTestServer } = require('@google-cloud/functions-framework/testing');
 
-describe('CloudFunctionV2 Running Broken Link Synthetics', async () => {
+describe.only('CloudFunctionV2 Running Broken Link Synthetics', async () => {
   const status_class_2xx = {
     status_class: ResponseStatusCode_StatusClass.STATUS_CLASS_2XX,
   };
-  const default_screenshot_options: BrokenLinksResultV1_BrokenLinkCheckerOptions_ScreenshotOptions =
+  const defaultScreenshotOptions: BrokenLinksResultV1_BrokenLinkCheckerOptions_ScreenshotOptions =
     {
       capture_condition: ApiCaptureCondition.FAILING,
       storage_location: '',
     };
 
-  const default_screenshot_output: BrokenLinksResultV1_SyntheticLinkResult_ScreenshotOutput =
+  const defaultScreenshotOutput: BrokenLinksResultV1_SyntheticLinkResult_ScreenshotOutput =
     {
       screenshot_file: '',
       screenshot_error: {} as BaseError,
     };
-
-  it('Handles error when trying to visit page that does not exist', async () => {
-    const server = getTestServer('BrokenLinksPageDoesNotExist');
-
-    // invoke SyntheticBrokenLinks with SuperTest
-    const response = await supertest(server)
-      .get('/')
-      .send()
-      .set('Content-Type', 'application/json')
-      .expect(200);
-
-    const output: SyntheticResult = response.body as SyntheticResult;
-    const start_time = output.start_time;
-    const end_time = output.end_time;
-    const broken_links_result = output?.synthetic_broken_links_result_v1;
-    const origin_link = broken_links_result?.origin_link_result;
-    const followed_links = broken_links_result?.followed_link_results;
-    const runtime_metadata = output?.runtime_metadata;
-
-    expect(start_time).to.be.a.string;
-    expect(end_time).to.be.a.string;
-
-    expect(broken_links_result?.link_count).to.equal(1);
-    expect(broken_links_result?.passing_link_count).to.equal(0);
-    expect(broken_links_result?.failing_link_count).to.equal(1);
-    expect(broken_links_result?.unreachable_count).to.equal(1);
-    expect(broken_links_result?.status2xx_count).to.equal(0);
-    expect(broken_links_result?.status3xx_count).to.equal(0);
-    expect(broken_links_result?.status4xx_count).to.equal(0);
-    expect(broken_links_result?.status5xx_count).to.equal(0);
-
-    const origin_uri = `file:${path.join(
-      __dirname,
-      '../example_html_files/file_doesnt_exist.html'
-    )}`;
-
-    expect(origin_link)
-      .excluding(['link_start_time', 'link_end_time'])
-      .to.deep.equal({
-        link_passed: false,
-        expected_status_code: status_class_2xx,
-        source_uri: origin_uri,
-        target_uri: origin_uri,
-        html_element: '',
-        anchor_text: '',
-        error_type: 'Error',
-        error_message: 'net::ERR_FILE_NOT_FOUND at ' + origin_uri,
-        link_start_time: 'NA',
-        link_end_time: 'NA',
-        is_origin: true,
-        screenshot_output: default_screenshot_output,
-      });
-
-    expect(followed_links).to.deep.equal([]);
-
-    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-api']).to.not.be
-      .undefined;
-    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-broken-links']).to
-      .not.be.undefined;
-  }).timeout(10000);
 
   it('Visits and checks empty page with no links', async () => {
     const server = getTestServer('BrokenLinksEmptyPageOk');
@@ -153,7 +96,7 @@ describe('CloudFunctionV2 Running Broken Link Synthetics', async () => {
       wait_for_selector: '',
       per_link_options: {},
       total_synthetic_timeout_millis: 60000,
-      screenshot_options: default_screenshot_options,
+      screenshot_options: defaultScreenshotOptions,
     });
 
     expect(origin_link)
@@ -171,269 +114,10 @@ describe('CloudFunctionV2 Running Broken Link Synthetics', async () => {
         link_start_time: 'NA',
         link_end_time: 'NA',
         is_origin: true,
-        screenshot_output: default_screenshot_output,
+        screenshot_output: defaultScreenshotOutput,
       });
 
     expect(followed_links).to.deep.equal([]);
-
-    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-api']).to.not.be
-      .undefined;
-    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-broken-links']).to
-      .not.be.undefined;
-  }).timeout(10000);
-
-  it('Exits early with generic_result when options cannot be parsed', async () => {
-    const server = getTestServer('BrokenLinksInvalidOptionsNotOk');
-
-    // invoke SyntheticBrokenLinks with SuperTest
-    const response = await supertest(server)
-      .get('/')
-      .send()
-      .set('Content-Type', 'application/json')
-      .expect(200);
-
-    const output: SyntheticResult = response.body as SyntheticResult;
-    const start_time = output.start_time;
-    const end_time = output.end_time;
-    const synthetic_generic_result = output?.synthetic_generic_result_v1;
-    const runtime_metadata = output?.runtime_metadata;
-
-    expect(synthetic_generic_result?.ok).to.be.false;
-    expect(synthetic_generic_result?.generic_error?.error_type).to.equal(
-      'Error'
-    );
-    expect(synthetic_generic_result?.generic_error?.error_message).to.equal(
-      'Invalid link_order value, must be `FIRST_N` or `RANDOM`'
-    );
-    expect(start_time).to.be.a.string;
-    expect(end_time).to.be.a.string;
-
-    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-api']).to.not.be
-      .undefined;
-    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-broken-links']).to
-      .not.be.undefined;
-  }).timeout(10000);
-
-  it('Runs a failing Broken Links suite', async () => {
-    const server = getTestServer('BrokenLinksFailingOk');
-
-    // invoke SyntheticBrokenLinks with SuperTest
-    const response = await supertest(server)
-      .get('/')
-      .send()
-      .set('Content-Type', 'application/json')
-      .expect(200);
-
-    const origin_uri = `file:${path.join(
-      __dirname,
-      '../example_html_files/retrieve_links_test.html'
-    )}`;
-
-    const output: SyntheticResult = response.body as SyntheticResult;
-    const start_time = output.start_time;
-    const end_time = output.end_time;
-    const broken_links_result = output?.synthetic_broken_links_result_v1;
-    const options = broken_links_result?.options;
-    const origin_link = broken_links_result?.origin_link_result;
-    const followed_links = broken_links_result?.followed_link_results;
-    const runtime_metadata = output?.runtime_metadata;
-
-    expect(start_time).to.be.a.string;
-    expect(end_time).to.be.a.string;
-
-    expect(broken_links_result?.link_count).to.equal(3);
-    expect(broken_links_result?.passing_link_count).to.equal(2);
-    expect(broken_links_result?.failing_link_count).to.equal(1);
-    expect(broken_links_result?.unreachable_count).to.equal(1);
-    expect(broken_links_result?.status2xx_count).to.equal(2);
-    expect(broken_links_result?.status3xx_count).to.equal(0);
-    expect(broken_links_result?.status4xx_count).to.equal(0);
-    expect(broken_links_result?.status5xx_count).to.equal(0);
-
-    expect(options).to.deep.equal({
-      origin_uri: origin_uri,
-      link_limit: 10,
-      query_selector_all: 'a[src], img[href]',
-      get_attributes: ['href', 'src'],
-      link_order:
-        BrokenLinksResultV1_BrokenLinkCheckerOptions_LinkOrder.FIRST_N,
-      link_timeout_millis: 30000,
-      max_retries: 0,
-      wait_for_selector: '',
-      per_link_options: {},
-      total_synthetic_timeout_millis: 60000,
-      screenshot_options: default_screenshot_options,
-    });
-
-    expect(origin_link)
-      .excluding(['link_start_time', 'link_end_time'])
-      .to.deep.equal({
-        link_passed: true,
-        expected_status_code: status_class_2xx,
-        source_uri: origin_uri,
-        target_uri: origin_uri,
-        html_element: '',
-        anchor_text: '',
-        status_code: 200,
-        error_type: '',
-        error_message: '',
-        link_start_time: 'NA',
-        link_end_time: 'NA',
-        is_origin: true,
-        screenshot_output: default_screenshot_output,
-      });
-
-    const sorted_followed_links = followed_links?.sort((a, b) =>
-      a.target_uri.localeCompare(b.target_uri)
-    );
-
-    const doesnt_exist_path = `file://${path.join(
-      __dirname,
-      '../example_html_files/file_doesnt_exist.html'
-    )}`
-      .split(' ')
-      .join('%20');
-    expect(sorted_followed_links)
-      .excluding(['target_uri', 'link_start_time', 'link_end_time'])
-      .to.deep.equal([
-        {
-          link_passed: true,
-          expected_status_code: status_class_2xx,
-          source_uri: origin_uri,
-          target_uri: 'CHECKED_BELOW',
-          html_element: 'a',
-          anchor_text: 'External Link',
-          status_code: 200,
-          error_type: '',
-          error_message: '',
-          link_start_time: 'NA',
-          link_end_time: 'NA',
-          is_origin: false,
-          screenshot_output: default_screenshot_output,
-        },
-        {
-          link_passed: false,
-          expected_status_code: { status_class: 200 },
-          source_uri: origin_uri,
-          target_uri: 'CHECKED_BELOW',
-          html_element: 'img',
-          anchor_text: '',
-          error_type: 'Error',
-          error_message: 'net::ERR_FILE_NOT_FOUND at ' + doesnt_exist_path,
-          link_start_time: 'NA',
-          link_end_time: 'NA',
-          is_origin: false,
-          screenshot_output: default_screenshot_output,
-        },
-      ]);
-
-    const expectedTargetPaths = [
-      'example_html_files/200.html',
-      'example_html_files/file_doesnt_exist.html',
-    ];
-    followed_links?.forEach((link, index) => {
-      expect(link.target_uri.endsWith(expectedTargetPaths[index]));
-    });
-
-    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-api']).to.not.be
-      .undefined;
-    expect(runtime_metadata?.['@google-cloud/synthetics-sdk-broken-links']).to
-      .not.be.undefined;
-  }).timeout(10000);
-
-  it('Runs a passing Broken Links suite', async () => {
-    const server = getTestServer('BrokenLinksPassingOk');
-
-    // invoke SyntheticBrokenLinks with SuperTest
-    const response = await supertest(server)
-      .get('/')
-      .send()
-      .set('Content-Type', 'application/json')
-      .expect(200);
-
-    const origin_uri = `file:${path.join(
-      __dirname,
-      '../example_html_files/retrieve_links_test.html'
-    )}`;
-
-    const output: SyntheticResult = response.body as SyntheticResult;
-    const start_time = output.start_time;
-    const end_time = output.end_time;
-    const broken_links_result = output?.synthetic_broken_links_result_v1;
-    const options = broken_links_result?.options;
-    const origin_link = broken_links_result?.origin_link_result;
-    const followed_links = broken_links_result?.followed_link_results;
-    const runtime_metadata = output?.runtime_metadata;
-
-    expect(start_time).to.be.a.string;
-    expect(end_time).to.be.a.string;
-
-    expect(broken_links_result?.link_count).to.equal(2);
-    expect(broken_links_result?.passing_link_count).to.equal(2);
-    expect(broken_links_result?.failing_link_count).to.equal(0);
-    expect(broken_links_result?.unreachable_count).to.equal(0);
-    expect(broken_links_result?.status2xx_count).to.equal(2);
-    expect(broken_links_result?.status3xx_count).to.equal(0);
-    expect(broken_links_result?.status4xx_count).to.equal(0);
-    expect(broken_links_result?.status5xx_count).to.equal(0);
-
-    expect(options).to.deep.equal({
-      origin_uri: origin_uri,
-      link_limit: 10,
-      query_selector_all: 'a[src]',
-      get_attributes: ['src'],
-      link_order:
-        BrokenLinksResultV1_BrokenLinkCheckerOptions_LinkOrder.FIRST_N,
-      link_timeout_millis: 30000,
-      max_retries: 0,
-      wait_for_selector: '',
-      per_link_options: {},
-      total_synthetic_timeout_millis: 60000,
-      screenshot_options: default_screenshot_options,
-    });
-
-    expect(origin_link)
-      .excluding(['link_start_time', 'link_end_time'])
-      .to.deep.equal({
-        link_passed: true,
-        expected_status_code: status_class_2xx,
-        source_uri: origin_uri,
-        target_uri: origin_uri,
-        html_element: '',
-        anchor_text: '',
-        status_code: 200,
-        error_type: '',
-        error_message: '',
-        link_start_time: 'NA',
-        link_end_time: 'NA',
-        is_origin: true,
-        screenshot_output: default_screenshot_output,
-      });
-
-    expect(followed_links)
-      .excluding(['target_uri', 'link_start_time', 'link_end_time'])
-      .to.deep.equal([
-        {
-          link_passed: true,
-          expected_status_code: status_class_2xx,
-          source_uri: origin_uri,
-          target_uri: 'CHECKED_BELOW',
-          html_element: 'a',
-          anchor_text: 'External Link',
-          status_code: 200,
-          error_type: '',
-          error_message: '',
-          link_start_time: 'NA',
-          link_end_time: 'NA',
-          is_origin: false,
-          screenshot_output: default_screenshot_output,
-        },
-      ]);
-
-    const expectedTargetPaths = ['example_html_files/200.html'];
-    followed_links?.forEach((link, index) => {
-      expect(link.target_uri.endsWith(expectedTargetPaths[index]));
-    });
 
     expect(runtime_metadata?.['@google-cloud/synthetics-sdk-api']).to.not.be
       .undefined;

--- a/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/link_utils.spec.ts
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Standard Libraries
 import { expect } from 'chai';
+
+// Internal Project Files
 import {
   BaseError,
   BrokenLinksResultV1_BrokenLinkCheckerOptions,

--- a/packages/synthetics-sdk-broken-links/test/unit/navigation_func.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/navigation_func.spec.ts
@@ -12,27 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Standard Libraries
 import { expect, use } from 'chai';
 import chaiExclude from 'chai-exclude';
 use(chaiExclude);
-
-import puppeteer, { Browser, HTTPResponse, Page } from 'puppeteer';
+const path = require('path');
 import sinon from 'sinon';
+
+// Internal Project Files
 import {
-  BrokenLinksResultV1_SyntheticLinkResult,
   BaseError,
+  BrokenLinksResultV1_SyntheticLinkResult,
   ResponseStatusCode,
   ResponseStatusCode_StatusClass,
 } from '@google-cloud/synthetics-sdk-api';
-import { LinkIntermediate } from '../../src/link_utils';
 import { BrokenLinkCheckerOptions } from '../../src/broken_links';
-const path = require('path');
+import { LinkIntermediate } from '../../src/link_utils';
 import {
   checkLink,
   navigate,
   retrieveLinksFromPage,
 } from '../../src/navigation_func';
 import { setDefaultOptions } from '../../src/options_func';
+
+// External Dependencies
+import puppeteer, { Browser, HTTPResponse, Page } from 'puppeteer';
 
 describe('GCM Synthetics Broken Links Navigation Functionality', async () => {
   // constants

--- a/packages/synthetics-sdk-broken-links/test/unit/options_func.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/options_func.spec.ts
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Standard Libraries
 import { expect } from 'chai';
+
+// Internal Project Files
 import {
   BrokenLinksResultV1_BrokenLinkCheckerOptions_LinkOrder,
   ResponseStatusCode,
@@ -20,8 +23,8 @@ import {
 } from '@google-cloud/synthetics-sdk-api';
 import {
   BrokenLinkCheckerOptions,
-  StatusClass,
   LinkOrder,
+  StatusClass,
 } from '../../src/broken_links';
 import {
   setDefaultOptions,

--- a/packages/synthetics-sdk-broken-links/test/unit/storage_func.spec.ts
+++ b/packages/synthetics-sdk-broken-links/test/unit/storage_func.spec.ts
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Standard Libraries
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { Storage, Bucket, File } from '@google-cloud/storage';
-import * as sdkApi from '@google-cloud/synthetics-sdk-api';
+
+// Internal Project Files
+import {
+  BaseError,
+  BrokenLinksResultV1_BrokenLinkCheckerOptions,
+  BrokenLinksResultV1_BrokenLinkCheckerOptions_ScreenshotOptions_CaptureCondition as ApiCaptureCondition,
+} from '@google-cloud/synthetics-sdk-api';
 import {
   createStorageClientIfStorageSelected,
   getFolderNameFromStorageLocation,
@@ -23,7 +29,9 @@ import {
   StorageParameters,
   uploadScreenshotToGCS,
 } from '../../src/storage_func';
-import { BrokenLinksResultV1_BrokenLinkCheckerOptions } from '@google-cloud/synthetics-sdk-api';
+
+// External Dependencies
+import { Bucket, File, Storage } from '@google-cloud/storage';
 const proxyquire = require('proxyquire');
 
 // global test vars
@@ -41,14 +49,8 @@ describe('GCM Synthetics Broken Links storage_func suite testing', () => {
     },
   });
 
-  const storage_condition_failing_links =
-    sdkApi
-      .BrokenLinksResultV1_BrokenLinkCheckerOptions_ScreenshotOptions_CaptureCondition
-      .FAILING;
-  const storage_condition_none =
-    sdkApi
-      .BrokenLinksResultV1_BrokenLinkCheckerOptions_ScreenshotOptions_CaptureCondition
-      .NONE;
+  const storage_condition_failing_links = ApiCaptureCondition.FAILING;
+  const storage_condition_none = ApiCaptureCondition.NONE;
 
   beforeEach(() => {
     // Stub a storage bucket
@@ -113,7 +115,7 @@ describe('GCM Synthetics Broken Links storage_func suite testing', () => {
     it('should handle errors during bucket.exists()', async () => {
       bucketStub.exists.throws(new Error('Simulated exists() error'));
 
-      const errors: sdkApi.BaseError[] = [];
+      const errors: BaseError[] = [];
       const result = await storageFunc.getOrCreateStorageBucket(
         storageClientStub,
         'user-bucket',
@@ -128,7 +130,7 @@ describe('GCM Synthetics Broken Links storage_func suite testing', () => {
     it('should handle errors during bucket creation', async () => {
       bucketStub.create.throws(new Error('Simulated creation error')); // Force an error
 
-      const errors: sdkApi.BaseError[] = [];
+      const errors: BaseError[] = [];
       const result = await storageFunc.getOrCreateStorageBucket(
         storageClientStub,
         '',


### PR DESCRIPTION
The integration.spec.ts and integration_server.js are "integration" tests in that they test the code within a mock cloud function environment. This is helpful to make sure that runtime_metadata is present and that http_headers are sent correctly. The current testing can almost entirely be done in the broken_links.spec.ts file, which is where I am migrating the code.
Because in the integration_server the broken_links package is imported as `const SyntheticsSdkBrokenLinks = require('synthetics-sdk-broken-links');` it makes code impossible to mock. So in anticipation of my integration with Cloud Storage, where I will need to mock lots of functionality I am moving these tests to broken_links.spec.ts

The cloud Storage integration will be integration tested through CEP workflows.

Also I've reorganized imports
