### PR TITLE
fix(remove-dep-on-ts-proto): Removes unnecessary ts-proto dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,16 @@
 on:
   push:
-    branches: [main]
   pull_request:
 name: ci
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node: [18, 20]
         include:
           # use latest npm by default
-          - npm-version: latest
+          - npm-version: 10.9.2
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
@@ -20,5 +19,5 @@ jobs:
       - run: node --version
       - name: Upgrade to latest npm to support lockfile v2
         run: npm install -g npm@${{ matrix.npm-version }}
-      - run: npm install && npm install
+      - run: npm ci --verbose && npm ci --verbose
       - run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -10511,7 +10511,7 @@
     },
     "packages/synthetics-sdk-api": {
       "name": "@google-cloud/synthetics-sdk-api",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/opentelemetry-cloud-trace-exporter": "2.1.0",
@@ -10524,7 +10524,6 @@
         "axios": "1.6.7",
         "error-stack-parser": "2.1.4",
         "google-auth-library": "9.0.0",
-        "ts-proto": "1.148.1",
         "winston": "3.10.0"
       },
       "devDependencies": {
@@ -10929,7 +10928,7 @@
     },
     "packages/synthetics-sdk-broken-links": {
       "name": "@google-cloud/synthetics-sdk-broken-links",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/storage": "^7.7.0",
@@ -11991,7 +11990,6 @@
         "node-mocks-http": "^1.13.0",
         "sinon": "^16.0.0",
         "supertest": "^6.3.3",
-        "ts-proto": "1.148.1",
         "winston": "3.10.0"
       },
       "dependencies": {

--- a/packages/synthetics-sdk-api/package.json
+++ b/packages/synthetics-sdk-api/package.json
@@ -40,11 +40,10 @@
     "@opentelemetry/sdk-node": "0.43.0",
     "@opentelemetry/sdk-trace-base": "1.17.0",
     "@opentelemetry/sdk-trace-node": "1.17.0",
+    "axios": "1.6.7",
     "error-stack-parser": "2.1.4",
     "google-auth-library": "9.0.0",
-    "ts-proto": "1.148.1",
-    "winston": "3.10.0",
-    "axios": "1.6.7"
+    "winston": "3.10.0"
   },
   "author": "Google Inc.",
   "license": "Apache-2.0"


### PR DESCRIPTION
Removes non-dev dependency on ts-proto, which had an indirect dependency on the taffydb module. https://nvd.nist.gov/vuln/detail/CVE-2019-10790. 

